### PR TITLE
feat(gesttalt): add homepage descriptions and archive

### DIFF
--- a/lib/gesttalt/mcp.ex
+++ b/lib/gesttalt/mcp.ex
@@ -561,9 +561,13 @@ defmodule Gesttalt.MCP do
       tool("get_publication", "Get publication identity, plan, and address settings", %{}),
       tool(
         "update_publication",
-        "Update the publication name or tagline",
+        "Update the publication name, tagline, or homepage description written in Markdown",
         %{
-          properties: %{name: string_schema(), tagline: string_schema()},
+          properties: %{
+            name: string_schema(),
+            tagline: string_schema(),
+            description: string_schema()
+          },
           required: []
         }
       ),
@@ -733,6 +737,7 @@ defmodule Gesttalt.MCP do
       name: site.name,
       handle: site.handle,
       tagline: site.tagline,
+      description: site.description,
       plan: Plans.tier(site),
       domains: Enum.map(Sites.list_domains(site), &present_domain/1)
     }

--- a/lib/gesttalt/publishing.ex
+++ b/lib/gesttalt/publishing.ex
@@ -22,6 +22,15 @@ defmodule Gesttalt.Publishing do
     published_query(site_id, :post) |> Repo.all()
   end
 
+  @doc "Lists the most recent public articles for a site."
+  def list_recent_published_posts(%Site{id: site_id}, limit \\ 3)
+      when is_integer(limit) and limit > 0 do
+    site_id
+    |> published_query(:post)
+    |> limit(^limit)
+    |> Repo.all()
+  end
+
   @doc "Lists one page of public articles and its pagination metadata."
   def paginate_published_posts(%Site{id: site_id}, page \\ 1) when is_integer(page) do
     published_query(site_id, :post)

--- a/lib/gesttalt/sites/site.ex
+++ b/lib/gesttalt/sites/site.ex
@@ -16,6 +16,7 @@ defmodule Gesttalt.Sites.Site do
     field :name, :string
     field :handle, :string
     field :tagline, :string
+    field :description, :string
     field :subscription_status, Ecto.Enum, values: @subscription_statuses, default: :inactive
     field :stripe_customer_id, :string
     field :stripe_subscription_id, :string
@@ -33,11 +34,12 @@ defmodule Gesttalt.Sites.Site do
 
   def changeset(site, attrs) do
     site
-    |> cast(attrs, [:user_id, :name, :handle, :tagline])
+    |> cast(attrs, [:user_id, :name, :handle, :tagline, :description])
     |> update_change(:handle, &normalize_handle/1)
     |> validate_required([:user_id, :name, :handle])
     |> validate_length(:name, max: 100)
     |> validate_length(:handle, min: 2, max: 40)
+    |> validate_length(:description, max: 20_000)
     |> validate_format(:handle, ~r/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
     |> unique_constraint(:user_id)
     |> unique_constraint(:handle)

--- a/lib/gesttalt/theme_editing.ex
+++ b/lib/gesttalt/theme_editing.ex
@@ -148,6 +148,7 @@ defmodule Gesttalt.ThemeEditing do
 
   @doc false
   def public_page_path(%{"kind" => "home"}), do: "/"
+  def public_page_path(%{"kind" => "archive"}), do: "/blog"
   def public_page_path(%{"kind" => "photography"}), do: "/photography"
 
   def public_page_path(%{"kind" => "article", "slug" => slug}),
@@ -161,6 +162,9 @@ defmodule Gesttalt.ThemeEditing do
       case path |> String.trim("/") |> String.split("/", trim: true) do
         [] ->
           {:ok, %{"kind" => "home", "title" => site.name}}
+
+        ["blog"] ->
+          {:ok, %{"kind" => "archive", "page" => 1, "title" => "Writing"}}
 
         ["blog", slug] ->
           page_for_slug(Publishing.list_published_posts(site), "article", URI.decode(slug))

--- a/lib/gesttalt/themes/renderer.ex
+++ b/lib/gesttalt/themes/renderer.ex
@@ -9,12 +9,25 @@ defmodule Gesttalt.Themes.Renderer do
   alias Gesttalt.Sites.{Image, Site, Theme, ThemeDefaults}
   alias Gesttalt.Themes.Variables
 
-  def render_index(%Site{} = site, %Theme{} = theme, posts, pages, pagination \\ nil, og \\ nil) do
+  def render_index(
+        %Site{} = site,
+        %Theme{} = theme,
+        posts,
+        pages,
+        pagination \\ nil,
+        og \\ nil,
+        options \\ []
+      ) do
+    archive? = Keyword.get(options, :archive, false)
+    archive_path = Keyword.get(options, :archive_path, "/blog")
+
     render(
       theme.index_template,
       base_context(site, theme, pages, og)
       |> Map.put("posts", Enum.map(posts, &post_context(&1, og)))
-      |> Map.put("pagination", pagination_context(pagination, length(posts)))
+      |> Map.put("archive_url", archive_path)
+      |> Map.put("is_archive", archive?)
+      |> Map.put("pagination", pagination_context(pagination, length(posts), archive_path))
     )
   end
 
@@ -80,7 +93,9 @@ defmodule Gesttalt.Themes.Renderer do
     |> Map.put("photos", [photo_context(photo)])
     |> Map.put("post", post_context(post))
     |> Map.put("page", post_context(%{post | title: "About", slug: "about", kind: :page}))
-    |> Map.put("pagination", pagination_context(nil, 1))
+    |> Map.put("archive_url", "/blog")
+    |> Map.put("is_archive", false)
+    |> Map.put("pagination", pagination_context(nil, 1, "/blog"))
   end
 
   defp render(template, context) do
@@ -97,7 +112,14 @@ defmodule Gesttalt.Themes.Renderer do
     variables = Variables.normalize(theme.variables)
 
     %{
-      "site" => %{"name" => site.name, "handle" => site.handle, "tagline" => site.tagline || ""},
+      "site" => %{
+        "name" => site.name,
+        "handle" => site.handle,
+        "tagline" => site.tagline || "",
+        "description" => site.description || "",
+        "description_html" => site.description |> to_html(),
+        "has_description" => has_description?(site.description)
+      },
       "pages" => Enum.map(pages, &post_context(&1, og)),
       "theme_variables" => variables,
       "og_image" => home_og_image(site, og),
@@ -123,6 +145,7 @@ defmodule Gesttalt.Themes.Renderer do
       "title" => post.title,
       "slug" => post.slug,
       "excerpt" => post.excerpt || "",
+      "has_excerpt" => has_excerpt?(post.excerpt),
       "tags" => post.tags || [],
       "body" => post.body,
       "body_html" => post.body |> Markdown.to_html() |> Phoenix.HTML.safe_to_string(),
@@ -151,7 +174,7 @@ defmodule Gesttalt.Themes.Renderer do
   defp escape(value),
     do: value |> then(&(&1 || "")) |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
 
-  defp pagination_context(%Flop.Meta{} = pagination, _post_count) do
+  defp pagination_context(%Flop.Meta{} = pagination, _post_count, archive_path) do
     current_page = pagination.current_page || 1
 
     %{
@@ -161,12 +184,14 @@ defmodule Gesttalt.Themes.Renderer do
       "page_size" => pagination.page_size || 0,
       "has_previous_page" => pagination.has_previous_page?,
       "has_next_page" => pagination.has_next_page?,
-      "previous_url" => if(pagination.has_previous_page?, do: pagination_url(current_page - 1)),
-      "next_url" => if(pagination.has_next_page?, do: pagination_url(current_page + 1))
+      "previous_url" =>
+        if(pagination.has_previous_page?, do: pagination_url(current_page - 1, archive_path)),
+      "next_url" =>
+        if(pagination.has_next_page?, do: pagination_url(current_page + 1, archive_path))
     }
   end
 
-  defp pagination_context(_pagination, post_count) do
+  defp pagination_context(_pagination, post_count, _archive_path) do
     %{
       "current_page" => 1,
       "total_pages" => if(post_count > 0, do: 1, else: 0),
@@ -179,6 +204,17 @@ defmodule Gesttalt.Themes.Renderer do
     }
   end
 
-  defp pagination_url(1), do: "/"
-  defp pagination_url(page), do: "/?page=#{page}"
+  defp pagination_url(1, archive_path), do: archive_path
+  defp pagination_url(page, archive_path), do: "#{archive_path}?page=#{page}"
+
+  defp to_html(nil), do: ""
+  defp to_html(markdown), do: markdown |> Markdown.to_html() |> Phoenix.HTML.safe_to_string()
+
+  defp has_description?(description) when is_binary(description),
+    do: String.trim(description) != ""
+
+  defp has_description?(_description), do: false
+
+  defp has_excerpt?(excerpt) when is_binary(excerpt), do: String.trim(excerpt) != ""
+  defp has_excerpt?(_excerpt), do: false
 end

--- a/lib/gesttalt/themes/variables.ex
+++ b/lib/gesttalt/themes/variables.ex
@@ -58,19 +58,19 @@ defmodule Gesttalt.Themes.Variables do
     },
     %{
       key: "fontSizes",
-      description: "Portable type sizes from supporting text through page headings.",
+      description: "One shared type size for publication text, including headings.",
       variables: [
-        %{key: "small", description: "Supporting and metadata text size.", default: "0.875rem"},
+        %{key: "small", description: "Supporting and metadata text size.", default: "1rem"},
         %{key: "body", description: "Default body text size.", default: "1rem"},
         %{
           key: "lead",
           description: "Introductory and emphasized body text size.",
-          default: "1.1rem"
+          default: "1rem"
         },
         %{
           key: "heading",
           description: "Primary page heading size.",
-          default: "clamp(1.75rem, 5vw, 2.6rem)"
+          default: "1rem"
         }
       ]
     },

--- a/lib/gesttalt_web/controllers/site_controller.ex
+++ b/lib/gesttalt_web/controllers/site_controller.ex
@@ -47,14 +47,30 @@ defmodule GesttaltWeb.SiteController do
   def home(%{assigns: %{current_site: nil}} = conn, params),
     do: conn |> put_view(html: GesttaltWeb.PageHTML) |> GesttaltWeb.PageController.home(params)
 
-  def home(%{assigns: %{current_site: site}} = conn, params) do
+  def home(%{assigns: %{current_site: site}} = conn, _params) do
+    og = og_context(conn, site)
+    posts = Publishing.list_recent_published_posts(site)
+
+    render_theme(conn, site, fn ->
+      Renderer.render_index(
+        site,
+        site.theme,
+        posts,
+        Publishing.list_published_pages(site),
+        nil,
+        og
+      )
+    end)
+  end
+
+  def archive(%{assigns: %{current_site: site}} = conn, params) do
     og = og_context(conn, site)
     page = page_number(params)
     {posts, pagination} = Publishing.paginate_published_posts(site, page)
     last_page = max(pagination.total_pages, 1)
 
     if page > last_page do
-      redirect(conn, to: page_path(last_page))
+      redirect(conn, to: archive_path(last_page))
     else
       render_theme(conn, site, fn ->
         Renderer.render_index(
@@ -63,7 +79,9 @@ defmodule GesttaltWeb.SiteController do
           posts,
           Publishing.list_published_pages(site),
           pagination,
-          og
+          og,
+          archive: true,
+          archive_path: "/blog"
         )
       end)
     end
@@ -201,6 +219,6 @@ defmodule GesttaltWeb.SiteController do
 
   defp page_number(_params), do: 1
 
-  defp page_path(1), do: "/"
-  defp page_path(page), do: "/?page=#{page}"
+  defp archive_path(1), do: "/blog"
+  defp archive_path(page), do: "/blog?page=#{page}"
 end

--- a/lib/gesttalt_web/controllers/site_settings_html/show.html.heex
+++ b/lib/gesttalt_web/controllers/site_settings_html/show.html.heex
@@ -27,6 +27,13 @@
           value={form[:tagline].value}
         />
       </div>
+      <div class="field" data-part="field">
+        <label for={form[:description].id}>Homepage description</label><textarea
+          id={form[:description].id}
+          name={form[:description].name}
+          rows="8"
+        >{form[:description].value}</textarea><p data-part="hint">Markdown is supported.</p>
+      </div>
       <button class="button button--primary">Save publication</button>
     </.form>
     <section id="settings-list">

--- a/lib/gesttalt_web/controllers/theme_preview_controller.ex
+++ b/lib/gesttalt_web/controllers/theme_preview_controller.ex
@@ -14,6 +14,10 @@ defmodule GesttaltWeb.ThemePreviewController do
     render_preview(conn, session_id, %{"kind" => "photography"})
   end
 
+  def archive(conn, %{"session_id" => session_id} = params) do
+    render_preview(conn, session_id, %{"kind" => "archive", "page" => page_number(params)})
+  end
+
   def article(conn, %{"session_id" => session_id, "slug" => slug}) do
     render_preview(conn, session_id, %{"kind" => "article", "slug" => slug})
   end
@@ -68,4 +72,13 @@ defmodule GesttaltWeb.ThemePreviewController do
 
   defp not_found(conn),
     do: conn |> put_status(:not_found) |> text("Theme editing session not found or expired.")
+
+  defp page_number(%{"page" => value}) do
+    case Integer.parse(to_string(value)) do
+      {page, ""} when page in 1..1_000_000 -> page
+      _invalid -> 1
+    end
+  end
+
+  defp page_number(_params), do: 1
 end

--- a/lib/gesttalt_web/live/theme_preview_live.ex
+++ b/lib/gesttalt_web/live/theme_preview_live.ex
@@ -320,14 +320,27 @@ defmodule GesttaltWeb.ThemePreviewLive do
   end
 
   defp render_page(site, theme, %{"kind" => "home"}) do
-    {posts, pagination} = Publishing.paginate_published_posts(site)
+    Renderer.render_index(
+      site,
+      theme,
+      Publishing.list_recent_published_posts(site),
+      Publishing.list_published_pages(site),
+      nil
+    )
+  end
+
+  defp render_page(site, theme, %{"kind" => "archive", "page" => page}) do
+    {posts, pagination} = Publishing.paginate_published_posts(site, page)
 
     Renderer.render_index(
       site,
       theme,
       posts,
       Publishing.list_published_pages(site),
-      pagination
+      pagination,
+      nil,
+      archive: true,
+      archive_path: "/blog"
     )
   end
 
@@ -404,6 +417,8 @@ defmodule GesttaltWeb.ThemePreviewLive do
     </html>
     """
   end
+
+  defp enrich_page(_site, %{"kind" => "archive"} = page), do: page
 
   defp enrich_page(site, page) do
     case ThemeEditing.page_for_path(site, "", ThemeEditing.public_page_path(page)) do

--- a/lib/gesttalt_web/router.ex
+++ b/lib/gesttalt_web/router.ex
@@ -176,6 +176,7 @@ defmodule GesttaltWeb.Router do
 
     get "/:session_id/media/:id/:filename", ThemePreviewController, :media
     get "/:session_id/photography", ThemePreviewController, :photography
+    get "/:session_id/blog", ThemePreviewController, :archive
     get "/:session_id/blog/:slug", ThemePreviewController, :article
     get "/:session_id/:slug", ThemePreviewController, :page
     get "/:session_id", ThemePreviewController, :home
@@ -224,6 +225,7 @@ defmodule GesttaltWeb.Router do
     pipe_through [:browser, :tenant]
     get "/", SiteController, :home
     get "/photography", SiteController, :photography
+    get "/blog", SiteController, :archive
     get "/blog/:slug", SiteController, :article
     get "/media/:id/:filename", SiteController, :media
     get "/og-image", OpenGraphController, :show

--- a/priv/changelog/2026-08-09-homepage-description-and-archive.md
+++ b/priv/changelog/2026-08-09-homepage-description-and-archive.md
@@ -1,0 +1,7 @@
+%{
+  title: "Introduce your publication on the home page",
+  summary: "Add a Markdown description to your publication and keep the home page focused on your latest writing."
+}
+---
+
+Publication settings now include a Markdown homepage description. The built-in themes show it above the three most recent posts, with a link to the complete paginated writing archive. This keeps a personal introduction visible without requiring a custom theme.

--- a/priv/changelog/2026-08-09-uniform-publication-type-size.md
+++ b/priv/changelog/2026-08-09-uniform-publication-type-size.md
@@ -1,0 +1,7 @@
+%{
+  title: "Use one text size across built-in themes",
+  summary: "Headings, introductory text, and supporting text now share the same type size."
+}
+---
+
+The built-in themes now use one type size across publication text, including headings. Hierarchy remains through weight, spacing, and layout rather than larger text.

--- a/priv/repo/migrations/20260809110000_add_description_to_sites.exs
+++ b/priv/repo/migrations/20260809110000_add_description_to_sites.exs
@@ -1,0 +1,9 @@
+defmodule Gesttalt.Repo.Migrations.AddDescriptionToSites do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sites) do
+      add :description, :text
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -60,6 +60,30 @@ if bootstrap_email do
         site
     end
 
+  site =
+    if Application.get_env(:gesttalt, :seed_demo) and is_nil(site.description) do
+      {:ok, site} =
+        Sites.update_site(site, %{
+          description: """
+          ## Hello, I’m writing from Gesttalt
+
+          A small independent publication about making software, paying attention, and leaving room for curiosity.
+
+          I use this space for:
+
+          - Notes from building products
+          - Essays on tools, teams, and craft
+          - Photographs and observations from everyday life
+
+          New writing arrives when there is something worth sharing. Start with the latest notes below, or browse the complete archive.
+          """
+        })
+
+      site
+    else
+      site
+    end
+
   if domain_name = System.get_env("GESTTALT_SEED_DOMAIN") do
     if !Enum.any?(Sites.list_domains(site), &(&1.hostname == domain_name)) do
       {:ok, domain} = Sites.add_custom_domain(site, %{hostname: domain_name})
@@ -102,10 +126,24 @@ if bootstrap_email do
     {:ok, _page} =
       Publishing.create_post(site, %{
         title: "About",
-        excerpt: "An independent publication.",
         body: "This is a standalone page, rendered by the same Liquid theme.",
         status: :published,
         kind: :page
       })
+
+    Enum.each(1..20, fn index ->
+      {:ok, _post} =
+        Publishing.create_post(site, %{
+          title: "Field note #{index}",
+          excerpt: "A short observation from the workbench.",
+          body: "A brief note for the development publication.",
+          status: :published,
+          kind: :post,
+          published_at:
+            DateTime.utc_now()
+            |> DateTime.add(-(index + 2) * 86_400, :second)
+            |> DateTime.truncate(:second)
+        })
+    end)
   end
 end

--- a/priv/themes/paper/index.liquid
+++ b/priv/themes/paper/index.liquid
@@ -15,7 +15,7 @@
     <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="/blog/atom.xml">
     <style>{{ stylesheet }}</style>
   </head>
-  <body id="site-home">
+  <body id="{% if is_archive %}site-blog{% else %}site-home{% endif %}">
     <header class="site-header">
       <div class="container header-inner">
         <div class="site-identity">
@@ -23,14 +23,15 @@
           <span class="site-tagline">{{ site.tagline }}</span>
         </div>
         <nav>
-          <a href="/">Writing</a>
+          <a href="/blog">Writing</a>
           <a href="/photography">Photography</a>
           {% for page in pages %}<a href="{{ page.url }}">{{ page.title }}</a>{% endfor %}
         </nav>
       </div>
     </header>
     <main class="container page">
-      <p class="section-label">Recent writing</p>
+      {% if site.has_description %}{% unless is_archive %}<section data-part="description" class="prose">{{ site.description_html }}</section>{% endunless %}{% endif %}
+      <p class="section-label">{% if is_archive %}Writing{% else %}Recent writing{% endif %}</p>
       <section class="posts-list">
         {% for post in posts %}
         <article class="post-row">
@@ -49,6 +50,7 @@
         {% if pagination.next_url %}<a data-part="next" href="{{ pagination.next_url }}">Older posts</a>{% endif %}
       </nav>
       {% endif %}
+      {% unless is_archive %}<p data-part="archive-link"><a href="{{ archive_url }}">View all writing</a></p>{% endunless %}
     </main>
     <footer id="site-footer">
       <div class="container" data-part="inner">

--- a/priv/themes/paper/page.liquid
+++ b/priv/themes/paper/page.liquid
@@ -17,7 +17,7 @@
   </head>
   <body>
     <header class="site-header"><div class="container header-inner"><div class="site-identity"><a class="site-title" href="/">{{ site.name }}</a><span class="site-tagline">{{ site.tagline }}</span></div><nav><a href="/">Writing</a><a href="/photography">Photography</a>{% for item in pages %}<a href="{{ item.url }}">{{ item.title }}</a>{% endfor %}</nav></div></header>
-    <main class="container page"><article><header class="article-header"><h1>{{ page.title }}</h1><p class="lede">{{ page.excerpt }}</p></header><div class="prose">{{ page.body_html }}</div></article></main>
+    <main class="container page"><article>{% if page.has_excerpt %}<header class="article-header"><p class="lede">{{ page.excerpt }}</p></header>{% endif %}<div class="prose">{{ page.body_html }}</div></article></main>
     <footer id="site-footer"><div class="container" data-part="inner"><span data-part="powered-by">Powered by <a href="https://gesttalt.org">Gesttalt</a></span></div></footer>
   </body>
 </html>

--- a/priv/themes/paper/theme.css
+++ b/priv/themes/paper/theme.css
@@ -27,7 +27,17 @@ h1 { font-family: var(--gesttalt-fonts-heading); font-size: var(--gesttalt-font-
 .prose code { background: var(--gesttalt-colors-surface); font-family: var(--gesttalt-fonts-monospace); font-size: .9em; padding: .1rem .3rem; }
 .prose pre { background: var(--gesttalt-colors-surface); border: 1px solid var(--gesttalt-colors-border); overflow-x: auto; padding: 1rem; }
 .prose pre code { padding: 0; }
-#site-home {
+#site-home, #site-blog {
+  & [data-part="description"] {
+    border-bottom: 1px solid var(--gesttalt-colors-border);
+    margin-bottom: 2.5rem;
+    padding-bottom: 2.5rem;
+  }
+
+  & [data-part="archive-link"] {
+    margin: 1.5rem 0 0;
+  }
+
   & #posts-pagination {
     display: grid;
     grid-template-columns: 1fr auto 1fr;

--- a/priv/themes/paper/theme.css
+++ b/priv/themes/paper/theme.css
@@ -19,9 +19,9 @@ nav { display: flex; flex-wrap: wrap; gap: 1rem; }
 .article-header { border-bottom: 1px solid var(--gesttalt-colors-border); margin-bottom: 1.75rem; padding-bottom: 1.25rem; }
 h1 { font-family: var(--gesttalt-fonts-heading); font-size: var(--gesttalt-font-sizes-heading); font-weight: var(--gesttalt-font-weights-heading); line-height: var(--gesttalt-line-heights-heading); letter-spacing: -.025em; margin: .25rem 0 .75rem; }
 .lede { color: var(--gesttalt-colors-muted-text); font-size: var(--gesttalt-font-sizes-lead); margin: 0; }
-.prose { font-size: 1.05rem; }
+.prose { font-size: var(--gesttalt-font-sizes-body); }
 .prose > * + * { margin-top: 1.15rem; }
-.prose h2, .prose h3 { font-family: var(--gesttalt-fonts-heading); font-weight: var(--gesttalt-font-weights-heading); line-height: 1.25; margin-top: 2rem; }
+.prose h2, .prose h3 { font-family: var(--gesttalt-fonts-heading); font-size: inherit; font-weight: var(--gesttalt-font-weights-heading); line-height: 1.25; margin-top: 2rem; }
 .prose img { max-width: 100%; height: auto; }
 .prose blockquote { border-left: 3px solid var(--gesttalt-colors-primary); color: var(--gesttalt-colors-muted-text); margin-left: 0; padding-left: 1rem; }
 .prose code { background: var(--gesttalt-colors-surface); font-family: var(--gesttalt-fonts-monospace); font-size: .9em; padding: .1rem .3rem; }

--- a/test/gesttalt/changelog_test.exs
+++ b/test/gesttalt/changelog_test.exs
@@ -7,10 +7,10 @@ defmodule Gesttalt.ChangelogTest do
     entries = Changelog.list()
     [latest | _rest] = entries
 
-    assert latest.slug == "photography-feed-layout"
+    assert latest.slug == "uniform-publication-type-size"
     assert latest.published_on == ~D[2026-08-09]
-    assert latest.title == "Default themes receive layout improvements"
-    assert latest.summary =~ "New sites inherit"
+    assert latest.title == "Use one text size across built-in themes"
+    assert latest.summary =~ "Headings, introductory text"
 
     assert entries ==
              Enum.sort_by(

--- a/test/gesttalt/themes/renderer_test.exs
+++ b/test/gesttalt/themes/renderer_test.exs
@@ -34,6 +34,18 @@ defmodule Gesttalt.Themes.RendererTest do
     refute html =~ "<script>"
   end
 
+  test "makes a sanitized publication description available to Liquid themes", %{site: site} do
+    {:ok, site} =
+      Sites.update_site(site, %{description: "## Hello\n\n<script>alert('no')</script>"})
+
+    {:ok, theme} =
+      Sites.update_theme(site, %{index_template: "<main>{{ site.description_html }}</main>"})
+
+    assert {:ok, html} = Renderer.render_index(site, theme, [], [])
+    assert html =~ "<h2>Hello</h2>"
+    refute html =~ "<script>"
+  end
+
   test "returns an error for invalid Liquid instead of crashing the request", %{site: site} do
     assert {:error, _reason} = Renderer.render_string("{% if site.name %}", %{"site" => site})
   end
@@ -75,10 +87,15 @@ defmodule Gesttalt.Themes.RendererTest do
       has_next_page?: true
     }
 
-    assert {:ok, html} = Renderer.render_index(site, theme, [], [], pagination)
+    assert {:ok, html} =
+             Renderer.render_index(site, theme, [], [], pagination, nil,
+               archive: true,
+               archive_path: "/blog"
+             )
+
     assert html =~ "<p>2 of 3</p>"
-    assert html =~ ~s(href="/")
-    assert html =~ ~s(href="/?page=3")
+    assert html =~ ~s(href="/blog")
+    assert html =~ ~s(href="/blog?page=3")
   end
 
   test "the built-in theme links every footer to Gesttalt", %{site: site} do
@@ -116,7 +133,7 @@ defmodule Gesttalt.Themes.RendererTest do
              ".header-inner { align-items: flex-start; display: flex; flex-direction: column; gap: 1.5rem; }"
 
     assert {:ok, html} = Renderer.render_index(site, theme, [], [])
-    assert html =~ ~s(<a href="/">Writing</a>)
+    assert html =~ ~s(<a href="/blog">Writing</a>)
     assert html =~ ~s(<a href="/photography">Photography</a>)
   end
 end

--- a/test/gesttalt/themes/variables_test.exs
+++ b/test/gesttalt/themes/variables_test.exs
@@ -45,4 +45,13 @@ defmodule Gesttalt.Themes.VariablesTest do
     assert stylesheet =~ "--gesttalt-font-sizes-body: 1rem;"
     assert stylesheet =~ "--gesttalt-line-heights-heading: 1.15;"
   end
+
+  test "uses one type size for publication text" do
+    assert Variables.defaults()["fontSizes"] == %{
+             "body" => "1rem",
+             "heading" => "1rem",
+             "lead" => "1rem",
+             "small" => "1rem"
+           }
+  end
 end

--- a/test/gesttalt_web/controllers/site_controller_test.exs
+++ b/test/gesttalt_web/controllers/site_controller_test.exs
@@ -53,7 +53,35 @@ defmodule GesttaltWeb.SiteControllerTest do
     refute body =~ ~s(id="gesttalt-owner-controls")
   end
 
-  test "paginates published posts and links between archive pages", %{
+  test "shows a Markdown description and the three newest posts on the home page", %{
+    conn: conn,
+    host: host,
+    site: site
+  } do
+    {:ok, site} =
+      Gesttalt.Sites.update_site(site, %{description: "## Hello\n\nI write about **software**."})
+
+    Enum.each(1..4, fn index ->
+      PublishingFixtures.post_fixture(%{
+        site: site,
+        title: "Article #{index}",
+        status: :published,
+        published_at: DateTime.add(~U[2026-01-01 00:00:00Z], index, :day)
+      })
+    end)
+
+    home = conn |> Map.put(:host, host) |> get(~p"/") |> html_response(200)
+
+    assert home =~ ~s(id="site-home")
+    assert home =~ "<h2>Hello</h2>"
+    assert home =~ "<strong>software</strong>"
+    assert home =~ ">Article 4</a>"
+    assert home =~ ">Article 2</a>"
+    refute home =~ ">Article 1</a>"
+    assert home =~ ~s(href="/blog">View all writing</a>)
+  end
+
+  test "paginates published posts in the writing archive", %{
     conn: conn,
     host: host,
     site: site
@@ -67,25 +95,26 @@ defmodule GesttaltWeb.SiteControllerTest do
       })
     end)
 
-    first_page = conn |> Map.put(:host, host) |> get(~p"/") |> html_response(200)
+    first_page = conn |> Map.put(:host, host) |> get(~p"/blog") |> html_response(200)
 
+    assert first_page =~ ~s(id="site-blog")
     assert first_page =~ ">Article 21</a>"
     assert first_page =~ ">Article 2</a>"
     refute first_page =~ ">Article 1</a>"
     assert first_page =~ ~s(id="posts-pagination")
-    assert first_page =~ ~s(href="/?page=2")
+    assert first_page =~ ~s(href="/blog?page=2")
     assert first_page =~ "Page 1 of 2"
 
     second_page =
       conn
       |> recycle()
       |> Map.put(:host, host)
-      |> get(~p"/?page=2")
+      |> get(~p"/blog?page=2")
       |> html_response(200)
 
     assert second_page =~ ">Article 1</a>"
     refute second_page =~ ">Article 2</a>"
-    assert second_page =~ ~s(href="/")
+    assert second_page =~ ~s(href="/blog")
     assert second_page =~ "Page 2 of 2"
   end
 
@@ -96,8 +125,8 @@ defmodule GesttaltWeb.SiteControllerTest do
   } do
     PublishingFixtures.post_fixture(%{site: site, status: :published})
 
-    conn = conn |> Map.put(:host, host) |> get(~p"/?page=3")
+    conn = conn |> Map.put(:host, host) |> get(~p"/blog?page=3")
 
-    assert redirected_to(conn) == "/"
+    assert redirected_to(conn) == "/blog"
   end
 end


### PR DESCRIPTION
## What changed

- Added a Markdown homepage description in publication settings, the publishing interface, and theme rendering.
- Changed the home page to show the three newest posts and linked it to a paginated `/blog` archive.
- Kept the archive available in theme previews and added development seed content for both views.
- Removed redundant standalone-page headings and empty excerpts from the sample About page.
- Unified built-in publication text sizes, including headings, while retaining hierarchy through weight and spacing.

## Why

Publications need a durable, theme-independent place to introduce themselves on the home page. Keeping the full archive separate lets the home page stay concise while preserving access to all writing.

## Approach

The description is stored on the publication and safely rendered into the theme context. Built-in themes use it only on the home page, so custom themes can choose another placement. The archive has its own route and pagination addresses, while reusing the same template structure.

## Impact

Owners can update the homepage introduction without customizing a theme. New and inherited built-in themes display the description, latest writing, and the archive link. Existing custom themes can opt in through the new theme context values.

## Validation

- `mix test test/gesttalt/themes/variables_test.exs test/gesttalt/themes/renderer_test.exs test/gesttalt_web/controllers/site_controller_test.exs`
- Seeded the local development database and verified the home page and paginated archive through local requests.
