### PR TITLE
fix(gesttalt): render social metadata for custom themes

### DIFF
--- a/lib/gesttalt/open_graph.ex
+++ b/lib/gesttalt/open_graph.ex
@@ -63,14 +63,29 @@ defmodule Gesttalt.OpenGraph do
   end
 
   # The version binds the URL (and therefore its signature) to the current
-  # content and theme so crawlers refetch a fresh image after an edit. It does
-  # not affect what gets rendered; the endpoint always renders live data.
+  # content and full theme definition so crawlers refetch a fresh image after
+  # an edit or theme change. It does not affect what gets rendered; the endpoint
+  # always renders live data.
   defp version(subject_updated_at, theme) do
-    "#{unix(subject_updated_at)}-#{unix(theme_updated_at(theme))}"
+    "#{unix(subject_updated_at)}-#{theme_fingerprint(theme)}"
   end
 
-  defp theme_updated_at(%{updated_at: updated_at}), do: updated_at
-  defp theme_updated_at(_theme), do: nil
+  defp theme_fingerprint(theme) do
+    theme
+    |> Map.from_struct()
+    |> Map.take([
+      :built_in_theme,
+      :variables,
+      :stylesheet,
+      :index_template,
+      :article_template,
+      :page_template,
+      :photography_template
+    ])
+    |> :erlang.term_to_binary([:deterministic])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+  end
 
   defp unix(%DateTime{} = datetime), do: Integer.to_string(DateTime.to_unix(datetime))
   defp unix(_other), do: "0"
@@ -90,6 +105,7 @@ defmodule Gesttalt.OpenGraph do
     with {:ok, subject} <- subject(site, params) do
       subject
       |> card_assigns(site)
+      |> Map.put(:theme_fingerprint, theme_fingerprint(site.theme))
       |> Card.html()
       |> fetch_or_render()
     end

--- a/lib/gesttalt/open_graph/card.ex
+++ b/lib/gesttalt/open_graph/card.ex
@@ -38,12 +38,14 @@ defmodule Gesttalt.OpenGraph.Card do
     title = Map.get(assigns, :title, "")
     subtitle = Map.get(assigns, :subtitle, "")
     meta = Map.get(assigns, :meta, "")
+    theme_fingerprint = Map.get(assigns, :theme_fingerprint, "")
 
     """
     <!doctype html>
     <html lang="en">
       <head>
         <meta charset="utf-8">
+        <!-- Theme: #{escape(theme_fingerprint)} -->
         <style>
           * { margin: 0; padding: 0; box-sizing: border-box; }
           html, body { width: #{@width}px; height: #{@height}px; }

--- a/lib/gesttalt/themes/renderer.ex
+++ b/lib/gesttalt/themes/renderer.ex
@@ -21,36 +21,43 @@ defmodule Gesttalt.Themes.Renderer do
     archive? = Keyword.get(options, :archive, false)
     archive_path = Keyword.get(options, :archive_path, "/blog")
 
-    render(
-      theme.index_template,
+    context =
       base_context(site, theme, pages, og)
       |> Map.put("posts", Enum.map(posts, &post_context(&1, og)))
       |> Map.put("archive_url", archive_path)
       |> Map.put("is_archive", archive?)
       |> Map.put("pagination", pagination_context(pagination, length(posts), archive_path))
-    )
+
+    render(theme.index_template, context, index_metadata(site, og, archive?))
   end
 
   def render_article(%Site{} = site, %Theme{} = theme, %Post{} = post, pages, og \\ nil) do
     render(
       theme.article_template,
-      base_context(site, theme, pages, og) |> Map.put("post", post_context(post, og))
+      base_context(site, theme, pages, og) |> Map.put("post", post_context(post, og)),
+      post_metadata(post, og, "article")
     )
   end
 
   def render_page(%Site{} = site, %Theme{} = theme, %Post{} = page, pages, og \\ nil) do
     render(
       theme.page_template,
-      base_context(site, theme, pages, og) |> Map.put("page", post_context(page, og))
+      base_context(site, theme, pages, og) |> Map.put("page", post_context(page, og)),
+      post_metadata(page, og, "website")
     )
   end
 
   def render_photography(%Site{} = site, %Theme{} = theme, photos, pages, og \\ nil) do
-    render(
-      theme.photography_template || ThemeDefaults.photography_template(),
+    context =
       base_context(site, theme, pages, og)
       |> Map.put("photos", Enum.map(photos, &photo_context/1))
-    )
+
+    render(theme.photography_template || ThemeDefaults.photography_template(), context, %{
+      type: "website",
+      title: "Photography · #{site.name}",
+      description: "A photography feed by #{site.name}",
+      image: home_og_image(site, og)
+    })
   end
 
   def render_string(template, context) when is_binary(template) and is_map(context),
@@ -98,15 +105,74 @@ defmodule Gesttalt.Themes.Renderer do
     |> Map.put("pagination", pagination_context(nil, 1, "/blog"))
   end
 
-  defp render(template, context) do
+  defp render(template, context, metadata \\ nil) do
     with {:ok, parsed} <- Solid.parse(template),
          {:ok, output, _context} <- Solid.render(parsed, context) do
-      {:ok, IO.iodata_to_binary(output)}
+      {:ok, output |> IO.iodata_to_binary() |> inject_metadata(metadata)}
     else
       {:error, errors, output} -> {:error, {errors, IO.iodata_to_binary(output)}}
       {:error, reason} -> {:error, reason}
     end
   end
+
+  defp index_metadata(site, og, true) do
+    %{
+      type: "website",
+      title: "Writing · #{site.name}",
+      description: site.description || site.tagline || "",
+      image: home_og_image(site, og)
+    }
+  end
+
+  defp index_metadata(site, og, false) do
+    %{
+      type: "website",
+      title: site.name,
+      description: site.tagline || site.description || "",
+      image: home_og_image(site, og)
+    }
+  end
+
+  defp post_metadata(post, og, type) do
+    %{
+      type: type,
+      title: post.title,
+      description: post.excerpt || "",
+      image: post_og_image(post, og)
+    }
+  end
+
+  defp inject_metadata(html, nil), do: html
+
+  defp inject_metadata(html, metadata) do
+    metadata_html =
+      [
+        {"property", "og:type", metadata.type},
+        {"property", "og:title", metadata.title},
+        {"property", "og:description", metadata.description},
+        {"property", "og:image", metadata.image},
+        {"name", "twitter:card", "summary_large_image"},
+        {"name", "twitter:image", metadata.image}
+      ]
+      |> Enum.map_join("\n", fn {attribute, name, content} ->
+        ~s(    <meta #{attribute}="#{name}" content="#{html_escape(content)}">)
+      end)
+
+    html
+    |> String.replace(
+      ~r/<meta\b[^>]*\b(?:property|name)\s*=\s*["'](?:og:(?:type|title|description|image)|twitter:(?:card|image))["'][^>]*>\s*/i,
+      ""
+    )
+    |> String.replace(~r|</head\s*>|i, "#{metadata_html}\n  </head>", global: false)
+  end
+
+  defp html_escape(value) when is_binary(value) do
+    value
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
+  end
+
+  defp html_escape(_value), do: ""
 
   defp base_context(site, theme, pages, og \\ nil) do
     variables = Variables.normalize(theme.variables)

--- a/priv/changelog/2026-08-09-reliable-open-graph-metadata.md
+++ b/priv/changelog/2026-08-09-reliable-open-graph-metadata.md
@@ -1,0 +1,7 @@
+%{
+  title: "Reliable social preview metadata",
+  summary: "Every public publication page now provides a current, theme-aware social preview image."
+}
+---
+
+Gesttalt now adds Open Graph and Twitter metadata to the home page, writing archive, articles, standalone pages, and photography feed even when a publication uses an older or customized theme template. Social preview images are refreshed when the selected theme changes, so shared links continue to match the publication’s design.

--- a/test/gesttalt/open_graph/card_test.exs
+++ b/test/gesttalt/open_graph/card_test.exs
@@ -70,4 +70,10 @@ defmodule Gesttalt.OpenGraph.CardTest do
     assert html =~ "1200px"
     assert html =~ "630px"
   end
+
+  test "includes the theme fingerprint in the rendered document" do
+    html = Card.html(%{variables: %{}, theme_fingerprint: "darkroom-v1"})
+
+    assert html =~ "<!-- Theme: darkroom-v1 -->"
+  end
 end

--- a/test/gesttalt/open_graph_test.exs
+++ b/test/gesttalt/open_graph_test.exs
@@ -4,6 +4,7 @@ defmodule Gesttalt.OpenGraphTest do
 
   alias Gesttalt.MediaStorage
   alias Gesttalt.OpenGraph
+  alias Gesttalt.Sites.ThemeDefaults
 
   import Gesttalt.AccountsFixtures
   import Gesttalt.PublishingFixtures
@@ -94,6 +95,15 @@ defmodule Gesttalt.OpenGraphTest do
         |> Map.put("id", Ecto.UUID.generate())
 
       refute OpenGraph.verify_signature(params)
+    end
+
+    test "changes the image URL when the selected theme changes", %{site: site} do
+      post = published_post(site)
+      base_context = %{site: site, theme: site.theme, base_url: "https://example.test"}
+      darkroom_context = %{base_context | theme: ThemeDefaults.theme(site.id, "darkroom")}
+
+      refute OpenGraph.image_url({:post, post}, base_context) ==
+               OpenGraph.image_url({:post, post}, darkroom_context)
     end
   end
 end

--- a/test/gesttalt_web/controllers/site_controller_test.exs
+++ b/test/gesttalt_web/controllers/site_controller_test.exs
@@ -129,4 +129,43 @@ defmodule GesttaltWeb.SiteControllerTest do
 
     assert redirected_to(conn) == "/blog"
   end
+
+  test "adds canonical social metadata to every public publication route", %{
+    conn: conn,
+    host: host,
+    site: site
+  } do
+    {:ok, post} =
+      Gesttalt.Publishing.publish_post(
+        PublishingFixtures.post_fixture(%{site: site, title: "An article"})
+      )
+
+    {:ok, page} =
+      Gesttalt.Publishing.publish_post(
+        PublishingFixtures.post_fixture(%{site: site, kind: :page, slug: "about", title: "About"})
+      )
+
+    for {path, type, title} <- [
+          {"/", "website", site.name},
+          {"/blog", "website", "Writing · #{site.name}"},
+          {"/blog/#{post.slug}", "article", post.title},
+          {"/#{page.slug}", "website", page.title},
+          {"/photography", "website", "Photography · #{site.name}"}
+        ] do
+      body = conn |> recycle() |> Map.put(:host, host) |> get(path) |> html_response(200)
+
+      assert body =~ ~s(<meta property="og:type" content="#{type}">)
+      assert body =~ ~s(<meta property="og:title" content="#{title}">)
+
+      assert body =~
+               ~r/<meta property="og:image" content="https?:\/\/#{Regex.escape(host)}\/og-image\?/
+
+      assert body =~ ~s(<meta name="twitter:card" content="summary_large_image">)
+
+      assert body =~
+               ~r/<meta name="twitter:image" content="https?:\/\/#{Regex.escape(host)}\/og-image\?/
+
+      assert length(Regex.scan(~r/<meta property="og:image"/, body)) == 1
+    end
+  end
 end


### PR DESCRIPTION
## What changed

- Add canonical social-preview metadata to the home page, writing archive, articles, standalone pages, and photography feed.
- Derive signed image URLs and rendered-image cache keys from the full selected-theme definition.
- Add regression coverage for every public publication route and theme changes.

## Why

Publications with older or customized templates could omit social-preview metadata, leaving shared links without a generated preview image.

## Root cause

Metadata was authored inside the editable built-in templates, so a saved template created before the feature was not updated when rendering support was introduced.

## Approach

Inject one canonical metadata set after rendering each public page. The renderer removes any existing equivalent tags first, so built-in and customized templates produce the same result without duplicates. A deterministic fingerprint of the selected theme is included in both the signed image URL version and the rendered card input.

## Impact

Existing publications receive current, theme-matched social-preview images without a template migration. Changing a theme causes crawlers to request a fresh image.

## Validation

- `mix test` (269 tests passed)
- Verified the locally rendered article HTML contains the canonical metadata.
- A headless browser session was unavailable in this environment, so no verification screenshot could be captured.
