### PR TITLE
fix(gesttalt): place flash bar below header

### DIFF
--- a/lib/gesttalt_web/components/layouts.ex
+++ b/lib/gesttalt_web/components/layouts.ex
@@ -67,10 +67,10 @@ defmodule GesttaltWeb.Layouts do
           </form>
         </div>
       </header>
+      <.flash_group flash={@flash} />
       <main class={["shell", @admin && "dashboard"]}>
         {render_slot(@inner_block)}
       </main>
-      <.flash_group flash={@flash} />
       <footer id="app-footer">
         <div class="shell" data-part="inner">
           <p data-part="identity">

--- a/test/gesttalt_web/controllers/theme_controller_test.exs
+++ b/test/gesttalt_web/controllers/theme_controller_test.exs
@@ -22,5 +22,14 @@ defmodule GesttaltWeb.ThemeControllerTest do
     response = conn |> recycle() |> get(~p"/admin/theme") |> html_response(200)
     assert response =~ "--paper: #f5f1e8"
     assert response =~ "font-family: Georgia, &#39;Times New Roman&#39;, serif"
+
+    assert element_position(response, "id=\"app-header\"") <
+             element_position(response, "id=\"flash-group\"")
+
+    assert element_position(response, "id=\"flash-group\"") < element_position(response, "<main")
+  end
+
+  defp element_position(html, selector) do
+    :binary.match(html, selector) |> elem(0)
   end
 end


### PR DESCRIPTION
## What changed

- Moved the shared flash message group directly below the application header.
- Added a controller regression test that verifies the header, flash message, and main content order.

## Why

Flash messages appeared immediately above the footer, separating confirmation from the action that caused it.

## Root cause

The shared layout rendered the flash message group after the main content.

## Impact

Confirmation and error messages now appear under the top navigation on every page that uses the shared application layout.

## Validation

- `mix format --check-formatted`
- The focused controller test was started: `mix test test/gesttalt_web/controllers/theme_controller_test.exs`. The shared test build did not complete before publication.
- Browser screenshots could not be captured because the local browser connection was unavailable in this session.
