### PR TITLE
feat(gesttalt): showcase built-in themes

### DIFF
--- a/assets/css/routes/home.css
+++ b/assets/css/routes/home.css
@@ -71,6 +71,88 @@
     }
   }
 
+  & > [data-part="themes"] {
+    border-bottom: 1px solid var(--line);
+    display: grid;
+    gap: var(--space-3);
+    margin-top: var(--space-6);
+    padding-bottom: var(--space-6);
+
+    & > [data-part="heading"] {
+      max-width: 680px;
+
+      & > [data-part="eyebrow"] {
+        color: var(--blue);
+        font-size: var(--font-size);
+        font-weight: 700;
+        letter-spacing: 0.02em;
+        margin: 0 0 var(--space-1);
+      }
+
+      & > h2 {
+        font-size: var(--font-size);
+        margin: 0;
+      }
+
+      & > p:last-child {
+        color: var(--muted);
+        margin: var(--space-1) 0 0;
+      }
+    }
+
+    & > [data-part="theme-grid"] {
+      display: grid;
+      gap: var(--space-2);
+      grid-template-columns: repeat(4, 1fr);
+    }
+
+    & [data-part="theme-card"] {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      min-width: 0;
+      overflow: hidden;
+
+      & > [data-part="preview"] {
+        aspect-ratio: 1.45;
+        display: grid;
+        gap: 0.55rem;
+        overflow: hidden;
+        padding: var(--space-2);
+        background: var(--preview-background);
+        color: var(--preview-ink);
+        font-family: var(--preview-font);
+
+        & > [data-part="preview-title"] {
+          font-size: 1.15rem;
+          font-weight: 700;
+          overflow-wrap: anywhere;
+        }
+
+        & > [data-part="preview-rule"] { border-top: 1px solid currentcolor; }
+
+        & > [data-part="preview-lines"] {
+          background: linear-gradient(currentcolor 0 0) 0 0 / 78% 1px no-repeat,
+            linear-gradient(currentcolor 0 0) 0 50% / 92% 1px no-repeat,
+            linear-gradient(currentcolor 0 0) 0 100% / 64% 1px no-repeat;
+          opacity: 0.55;
+        }
+      }
+
+      & > [data-part="content"] {
+        padding: var(--space-2);
+
+        & > h3 { margin: 0; }
+
+        & > p {
+          color: var(--muted);
+          margin: var(--space-1) 0 0;
+        }
+      }
+    }
+
+    & > a { justify-self: start; }
+  }
+
   & > [data-part="manifesto"] {
     border-bottom: 1px solid var(--line);
     margin: var(--space-6) 0;
@@ -111,6 +193,16 @@
         border-bottom: 1px solid var(--line);
         padding-inline: 0;
       }
+    }
+
+    & > [data-part="themes"] {
+      & > [data-part="theme-grid"] { grid-template-columns: repeat(2, 1fr); }
+    }
+  }
+
+  @media (max-width: 480px) {
+    & > [data-part="themes"] {
+      & > [data-part="theme-grid"] { grid-template-columns: 1fr; }
     }
   }
 }

--- a/lib/gesttalt_web/controllers/page_controller.ex
+++ b/lib/gesttalt_web/controllers/page_controller.ex
@@ -4,6 +4,7 @@ defmodule GesttaltWeb.PageController do
   alias Gesttalt.Changelog
   alias Gesttalt.IllegalContentReportProtection
   alias Gesttalt.Legal
+  alias Gesttalt.Sites.ThemeDefaults
   alias GesttaltWeb.ClientAddress
 
   def home(conn, _params) do
@@ -13,7 +14,10 @@ defmodule GesttaltWeb.PageController do
         dgettext(
           "marketing",
           "Agent-native publishing for content, media, themes, domains, and the complete publication."
-        )
+        ),
+      built_in_themes:
+        ThemeDefaults.all()
+        |> Enum.map(&Map.put(&1, :preview_style, ThemeDefaults.preview_style(&1.id)))
     )
   end
 

--- a/lib/gesttalt_web/controllers/page_html/home.html.heex
+++ b/lib/gesttalt_web/controllers/page_html/home.html.heex
@@ -47,6 +47,30 @@
         </p>
       </article>
     </section>
+    <section data-part="themes" aria-labelledby="built-in-themes-title">
+      <div data-part="heading">
+        <p data-part="eyebrow">Built-in themes</p><h2 id="built-in-themes-title">
+          Start with a point of view
+        </h2><p>
+          Every publication begins with a complete, editable design. Choose the one that feels closest to your work, then make it your own.
+        </p>
+      </div>
+      <div data-part="theme-grid">
+        <article
+          :for={theme <- @built_in_themes}
+          id={"marketing-theme-#{theme.id}"}
+          data-part="theme-card"
+        >
+          <div data-part="preview" aria-hidden="true" style={theme.preview_style}>
+            <span data-part="preview-title">{theme.name}</span><span data-part="preview-rule"></span><span data-part="preview-lines"></span>
+          </div>
+          <div data-part="content">
+            <h3>{theme.name}</h3><p>{theme.description}</p>
+          </div>
+        </article>
+      </div>
+      <a href={~p"/docs#themes"}>Learn about themes →</a>
+    </section>
     <section data-part="manifesto">
       <p data-part="eyebrow">Themes are code</p><h2 data-part="title">
         Design the publication in the same conversation that runs it.

--- a/test/gesttalt_web/controllers/page_controller_test.exs
+++ b/test/gesttalt_web/controllers/page_controller_test.exs
@@ -7,6 +7,12 @@ defmodule GesttaltWeb.PageControllerTest do
 
     assert html =~ "A blog your agents can run. A publication you own."
     assert html =~ "Manage the whole publication"
+    assert html =~ ~s(id="built-in-themes-title")
+
+    for theme <- ["Paper", "Ledger", "Darkroom", "Field Notes"] do
+      assert html =~ theme
+    end
+
     assert html =~ "Gesttalt is open source."
     assert html =~ ~s(href="https://github.com/pepicrft/gesttalt")
     refute html =~ ~r/pricing|payment|free|€|per month|upgrade/i


### PR DESCRIPTION
## What changed

- Added a built-in theme gallery to the marketing home page for Paper, Ledger, Darkroom, and Field Notes.
- Reused the canonical theme definitions and their preview styles, so the gallery stays aligned with selectable publication themes.
- Added responsive layouts for four, two, and one-column galleries.
- Covered the rendered theme gallery in the home-page controller test.

## Why

Visitors can now see the default publication themes before creating an account, making the available design directions tangible rather than only described.

## Impact

The public home page now presents the four maintained starting themes and links to the theme guide. No publication theme data changes.

## Validation

- `mix test test/gesttalt_web/controllers/page_controller_test.exs` (7 passed)
- Built assets with `mix assets.build`.
- Ran the application locally and captured before and after home-page screenshots in headless Chrome.

## Screenshots

Before and after screenshots were captured at a 1440-pixel viewport during local verification. The after screenshot shows the new built-in theme gallery directly below the feature cards.
