### PR TITLE
fix(gesttalt): keep proxy online during app rollouts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -146,11 +146,24 @@ jobs:
             document["kind"] == "ExternalSecret" &&
               document.dig("metadata", "name") == "gesttalt-app-env"
           end
-          deployment = documents.find { |document| document["kind"] == "Deployment" }
+          deployment = documents.find do |document|
+            document["kind"] == "Deployment" && document.dig("metadata", "name") == "gesttalt"
+          end
+          caddy_deployment = documents.find do |document|
+            document["kind"] == "Deployment" && document.dig("metadata", "name") == "gesttalt-caddy"
+          end
           migration = documents.find { |document| document["kind"] == "Job" }
           service = documents.find { |document| document["kind"] == "Service" }
+          web_service = documents.find do |document|
+            document["kind"] == "Service" && document.dig("metadata", "name") == "gesttalt-web"
+          end
           disruption_budget = documents.find { |document| document["kind"] == "PodDisruptionBudget" }
-          network_policy = documents.find { |document| document["kind"] == "NetworkPolicy" }
+          caddy_network_policy = documents.find do |document|
+            document["kind"] == "NetworkPolicy" && document.dig("metadata", "name") == "gesttalt-caddy-ingress"
+          end
+          web_network_policy = documents.find do |document|
+            document["kind"] == "NetworkPolicy" && document.dig("metadata", "name") == "gesttalt-web-ingress"
+          end
           scheduled_backup = documents.find { |document| document["kind"] == "ScheduledBackup" }
           media_claim = documents.find do |document|
             document["kind"] == "PersistentVolumeClaim" &&
@@ -221,19 +234,24 @@ jobs:
             abort("production temporary volume is too small for the browser pool")
           end
           abort("production service traffic policy is not local") unless service&.dig("spec", "externalTrafficPolicy") == "Local"
+          abort("production service does not select the Caddy pods") unless service&.dig("spec", "selector", "app.kubernetes.io/component") == "caddy"
+          abort("web service does not select the application pods") unless web_service&.dig("spec", "selector", "app.kubernetes.io/component") == "web"
           rollout = deployment&.dig("spec", "strategy", "rollingUpdate")
-          safe_volume_handover = rollout&.fetch("maxSurge", nil) == 0 &&
-            rollout&.fetch("maxUnavailable", nil) == 1
-          abort("single-node volume rollout handover is unsafe") unless safe_volume_handover
+          safe_application_rollout = rollout&.fetch("maxSurge", nil) == 1 &&
+            rollout&.fetch("maxUnavailable", nil) == 0
+          abort("application rollout can make the only pod unavailable") unless safe_application_rollout
           abort("production disruption budget is missing") unless disruption_budget
-          abort("production ingress policy is missing") unless network_policy
+          abort("production Caddy ingress policy is missing") unless caddy_network_policy
+          abort("production application ingress policy is missing") unless web_network_policy
           abort("production database backup is missing") unless scheduled_backup&.dig("spec", "cluster", "name") == "gesttalt-postgres"
           abort("unused production media claim is still rendered") if media_claim
           abort("production Caddy data claim is missing") unless caddy_claim
-          ownership_migration = deployment&.dig("spec", "template", "spec", "initContainers")&.find do |container|
+          ownership_migration = caddy_deployment&.dig("spec", "template", "spec", "initContainers")&.find do |container|
             container["name"] == "migrate-caddy-data-ownership"
           end
           abort("retained Caddy data ownership migration is missing") unless ownership_migration&.dig("securityContext", "runAsUser") == 0
+          app_volumes = deployment&.dig("spec", "template", "spec", "volumes") || []
+          abort("application deployment still mounts Caddy data") if app_volumes.any? { |volume| volume["name"] == "caddy-data" }
           [deployment, migration].each do |workload|
             media_volume = workload&.dig("spec", "template", "spec", "volumes")&.find do |volume|
               volume["name"] == "media"
@@ -262,7 +280,12 @@ jobs:
 
           ruby -ryaml <<'RUBY'
           documents = YAML.load_stream(File.read("/tmp/gesttalt-kind.yaml"))
-          deployment = documents.find { |document| document["kind"] == "Deployment" }
+          deployment = documents.find do |document|
+            document["kind"] == "Deployment" && document.dig("metadata", "name") == "gesttalt"
+          end
+          caddy_deployment = documents.find do |document|
+            document["kind"] == "Deployment" && document.dig("metadata", "name") == "gesttalt-caddy"
+          end
           database = documents.find { |document| document["kind"] == "StatefulSet" }
           migration = documents.find { |document| document["kind"] == "Job" }
           cloud_database = documents.find { |document| document["kind"] == "Cluster" }
@@ -274,6 +297,7 @@ jobs:
           abort("local deployment selector does not isolate the web pods") unless selector == "web"
           abort("local deployment does not wait for PostgreSQL") unless init_names.include?("wait-for-postgres")
           abort("local deployment does not run migrations") unless init_names.include?("migrate")
+          abort("local Caddy deployment is missing") unless caddy_deployment
           abort("local chart unexpectedly renders a migration Job") if migration
           abort("local chart unexpectedly renders a CloudNativePG Cluster") if cloud_database
           RUBY

--- a/deploy/helm/gesttalt/templates/caddy-config.yaml
+++ b/deploy/helm/gesttalt/templates/caddy-config.yaml
@@ -17,7 +17,7 @@ data:
       }
       {{- end }}
       on_demand_tls {
-        ask http://127.0.0.1:4000/internal/domains/allow
+        ask http://{{ include "gesttalt.fullname" . }}-web:4000/internal/domains/allow
       }
     }
 
@@ -29,13 +29,13 @@ data:
       tls {
         on_demand
       }
-      reverse_proxy 127.0.0.1:4000 {
+      reverse_proxy {{ include "gesttalt.fullname" . }}-web:4000 {
         header_up X-Forwarded-For {client_ip}
       }
     }
     {{- else }}
     http://:{{ .Values.caddy.httpPort }} {
-      reverse_proxy 127.0.0.1:4000 {
+      reverse_proxy {{ include "gesttalt.fullname" . }}-web:4000 {
         header_up X-Forwarded-For {client_ip}
       }
     }

--- a/deploy/helm/gesttalt/templates/caddy-deployment.yaml
+++ b/deploy/helm/gesttalt/templates/caddy-deployment.yaml
@@ -1,0 +1,167 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gesttalt.fullname" . }}-caddy
+  labels:
+    {{- include "gesttalt.labels" . | nindent 4 }}
+    app.kubernetes.io/component: caddy
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "gesttalt.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: caddy
+  template:
+    metadata:
+      annotations:
+        checksum/caddy: {{ include (print $.Template.BasePath "/caddy-config.yaml") . | sha256sum }}
+      labels:
+        {{- include "gesttalt.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: caddy
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: prepare-caddy-binary
+          image: {{ .Values.caddy.image | quote }}
+          command:
+            - /bin/sh
+            - -ec
+            - cp /usr/bin/caddy /caddy-bin/caddy && chmod 0555 /caddy-bin/caddy
+          resources:
+            {{- toYaml .Values.caddy.permissionsResources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+          volumeMounts:
+            - name: caddy-bin
+              mountPath: /caddy-bin
+        {{- if .Values.caddy.persistence.enabled }}
+        - name: migrate-caddy-data-ownership
+          image: {{ .Values.caddy.permissionsImage | quote }}
+          command:
+            - chown
+            - -R
+            - "65534:65534"
+            - /data
+          resources:
+            {{- toYaml .Values.caddy.permissionsResources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - DAC_OVERRIDE
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+          volumeMounts:
+            - name: caddy-data
+              mountPath: /data
+        {{- end }}
+      containers:
+        - name: caddy
+          image: {{ .Values.caddy.image | quote }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /caddy-bin/caddy
+            - run
+            - --config
+            - /etc/caddy/Caddyfile
+            - --adapter
+            - caddyfile
+          ports:
+            - name: http
+              containerPort: {{ .Values.caddy.httpPort }}
+            {{- if .Values.caddy.tls.enabled }}
+            - name: https
+              containerPort: {{ .Values.caddy.httpsPort }}
+            {{- end }}
+          env:
+            - name: XDG_CONFIG_HOME
+              value: /data/config
+          readinessProbe:
+            tcpSocket:
+              {{- if .Values.caddy.tls.enabled }}
+              port: https
+              {{- else }}
+              port: http
+              {{- end }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+          volumeMounts:
+            - name: caddy-config
+              mountPath: /etc/caddy
+              readOnly: true
+            - name: caddy-data
+              mountPath: /data
+            - name: tmp
+              mountPath: /tmp
+            - name: caddy-bin
+              mountPath: /caddy-bin
+              readOnly: true
+      volumes:
+        - name: caddy-data
+          {{- if .Values.caddy.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "gesttalt.fullname" . }}-caddy
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: caddy-config
+          configMap:
+            name: {{ include "gesttalt.fullname" . }}-caddy
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.temporaryFiles.sizeLimit }}
+        - name: caddy-bin
+          emptyDir:
+            sizeLimit: 64Mi
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/gesttalt/templates/deployment.yaml
+++ b/deploy/helm/gesttalt/templates/deployment.yaml
@@ -136,57 +136,6 @@ spec:
               readOnly: true
             {{- end }}
         {{- end }}
-        # The upstream image grants the Caddy executable permission to bind low
-        # ports. Copying it without that file capability lets the non-root
-        # container execute it under the no-privilege-escalation policy. The
-        # application only listens on the unprivileged ports below.
-        - name: prepare-caddy-binary
-          image: {{ .Values.caddy.image | quote }}
-          command:
-            - /bin/sh
-            - -ec
-            - cp /usr/bin/caddy /caddy-bin/caddy && chmod 0555 /caddy-bin/caddy
-          resources:
-            {{- toYaml .Values.caddy.permissionsResources | nindent 12 }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: false
-            runAsUser: 0
-          volumeMounts:
-            - name: caddy-bin
-              mountPath: /caddy-bin
-        {{- if .Values.caddy.persistence.enabled }}
-        - name: migrate-caddy-data-ownership
-          image: {{ .Values.caddy.permissionsImage | quote }}
-          command:
-            - chown
-            - -R
-            - "65534:65534"
-            - /data
-          resources:
-            {{- toYaml .Values.caddy.permissionsResources | nindent 12 }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-              add:
-                - CHOWN
-                # Existing Caddy directories can be private to their previous
-                # owner, so the migration needs the capability below to
-                # traverse them.
-                - DAC_OVERRIDE
-            readOnlyRootFilesystem: true
-            runAsNonRoot: false
-            runAsUser: 0
-          volumeMounts:
-            - name: caddy-data
-              mountPath: /data
-        {{- end }}
       containers:
         - name: web
           image: {{ include "gesttalt.image" . | quote }}
@@ -257,62 +206,6 @@ spec:
               subPath: ca-certificates.crt
               readOnly: true
             {{- end }}
-        - name: caddy
-          image: {{ .Values.caddy.image | quote }}
-          imagePullPolicy: IfNotPresent
-          command:
-            - /caddy-bin/caddy
-            - run
-            - --config
-            - /etc/caddy/Caddyfile
-            - --adapter
-            - caddyfile
-          ports:
-            - name: http
-              containerPort: {{ .Values.caddy.httpPort }}
-            {{- if .Values.caddy.tls.enabled }}
-            - name: https
-              containerPort: {{ .Values.caddy.httpsPort }}
-            {{- end }}
-          env:
-            - name: XDG_CONFIG_HOME
-              value: /data/config
-          readinessProbe:
-            tcpSocket:
-              {{- if .Values.caddy.tls.enabled }}
-              port: https
-              {{- else }}
-              port: http
-              {{- end }}
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          resources:
-            requests:
-              cpu: 50m
-              memory: 64Mi
-            limits:
-              cpu: 500m
-              memory: 256Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
-          volumeMounts:
-            - name: caddy-config
-              mountPath: /etc/caddy
-              readOnly: true
-            - name: caddy-data
-              mountPath: /data
-            - name: tmp
-              mountPath: /tmp
-            - name: caddy-bin
-              mountPath: /caddy-bin
-              readOnly: true
       volumes:
         {{- if or .Values.media.persistence.enabled (not .Values.media.objectStorage.enabled) }}
         - name: media
@@ -323,22 +216,9 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
-        - name: caddy-data
-          {{- if .Values.caddy.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ include "gesttalt.fullname" . }}-caddy
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
-        - name: caddy-config
-          configMap:
-            name: {{ include "gesttalt.fullname" . }}-caddy
         - name: tmp
           emptyDir:
             sizeLimit: {{ .Values.temporaryFiles.sizeLimit }}
-        - name: caddy-bin
-          emptyDir:
-            sizeLimit: 64Mi
         {{- if .Values.postgres.tls.enabled }}
         - name: database-certificate-authority
           secret:

--- a/deploy/helm/gesttalt/templates/network-policy.yaml
+++ b/deploy/helm/gesttalt/templates/network-policy.yaml
@@ -2,14 +2,14 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "gesttalt.fullname" . }}-ingress
+  name: {{ include "gesttalt.fullname" . }}-caddy-ingress
   labels:
     {{- include "gesttalt.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
       {{- include "gesttalt.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: web
+      app.kubernetes.io/component: caddy
   policyTypes:
     - Ingress
   ingress:
@@ -21,3 +21,26 @@ spec:
           protocol: TCP
         {{- end }}
 {{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "gesttalt.fullname" . }}-web-ingress
+  labels:
+    {{- include "gesttalt.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "gesttalt.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "gesttalt.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: caddy
+      ports:
+        - port: 4000
+          protocol: TCP

--- a/deploy/helm/gesttalt/templates/service.yaml
+++ b/deploy/helm/gesttalt/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
   {{- end }}
   selector:
     {{- include "gesttalt.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: caddy
   ports:
     - name: http
       port: {{ .Values.service.httpPort }}

--- a/deploy/helm/gesttalt/templates/web-service.yaml
+++ b/deploy/helm/gesttalt/templates/web-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gesttalt.fullname" . }}-web
+  labels:
+    {{- include "gesttalt.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "gesttalt.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+  ports:
+    - name: phoenix
+      port: 4000
+      targetPort: phoenix

--- a/deploy/values-production.yaml
+++ b/deploy/values-production.yaml
@@ -69,8 +69,8 @@ nodeSelector:
 strategy:
   type: RollingUpdate
   rollingUpdate:
-    maxSurge: 0
-    maxUnavailable: 1
+    maxSurge: 1
+    maxUnavailable: 0
 
 postgres:
   mode: cloudnative


### PR DESCRIPTION
## What changed

- Split Caddy into its own Deployment and route public traffic to it.
- Added an internal web Service for Caddy to reach the Gesttalt application.
- Kept Caddy's persistent certificate data volume with the proxy Deployment.
- Restored the application rollout policy that keeps the existing web pod available until its replacement is ready.
- Added chart-rendering assertions for the proxy and application topology.

## Why

Application releases should not restart the public proxy or detach its persistent certificate data volume.

## Root cause

The web application and Caddy previously shared a single pod. Production uses one replica and Caddy has a single-writer persistent volume, so an image update terminated the serving pod before its replacement could attach that volume. This caused a temporary loss of service during the analytics rollout.

## Approach

Caddy now has an independent lifecycle and forwards requests to a dedicated in-cluster web Service. The web deployment does not mount Caddy storage, so it can use a no-unavailable-pods rolling update without waiting for the proxy volume.

The first deployment of this layout still performs a one-time Caddy volume handover. Subsequent application image releases leave the proxy and its certificate data mounted and serving traffic.

## Impact

Future Gesttalt application releases can roll the web pods without restarting the public proxy or interrupting TLS traffic.

## Validation

- `helm lint deploy/helm/gesttalt`
- `helm lint deploy/helm/gesttalt --values deploy/helm/gesttalt/values-kind.yaml`
- `helm lint deploy/helm/gesttalt --values deploy/values-production.yaml`
- Rendered and inspected production and local chart topologies.
- `helm package deploy/helm/gesttalt --destination /tmp`
