### PR TITLE
fix(gesttalt): authorize Caddy certificates internally

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -173,6 +173,9 @@ jobs:
             document["kind"] == "PersistentVolumeClaim" &&
               document.dig("metadata", "name") == "gesttalt-caddy"
           end
+          caddy_config = documents.find do |document|
+            document["kind"] == "ConfigMap" && document.dig("metadata", "name") == "gesttalt-caddy"
+          end
           template = pull_secret&.dig("spec", "target", "template", "data", ".dockerconfigjson")
           expected_auth = '{{ printf `%s:%s` .GHCR_PULL_USERNAME .GHCR_PULL_TOKEN | b64enc }}'
           expected_app_keys = %w[
@@ -246,6 +249,9 @@ jobs:
           abort("production database backup is missing") unless scheduled_backup&.dig("spec", "cluster", "name") == "gesttalt-postgres"
           abort("unused production media claim is still rendered") if media_claim
           abort("production Caddy data claim is missing") unless caddy_claim
+          caddyfile = caddy_config&.dig("data", "Caddyfile")
+          abort("Caddy domain authorization is not routed internally") unless caddyfile&.include?("ask http://127.0.0.1:8080/internal/domains/allow")
+          abort("Caddy domain authorization does not preserve HTTPS") unless caddyfile&.include?("header_up X-Forwarded-Proto https")
           ownership_migration = caddy_deployment&.dig("spec", "template", "spec", "initContainers")&.find do |container|
             container["name"] == "migrate-caddy-data-ownership"
           end

--- a/deploy/helm/gesttalt/templates/caddy-config.yaml
+++ b/deploy/helm/gesttalt/templates/caddy-config.yaml
@@ -17,11 +17,18 @@ data:
       }
       {{- end }}
       on_demand_tls {
-        ask http://{{ include "gesttalt.fullname" . }}-web:4000/internal/domains/allow
+        ask http://127.0.0.1:{{ .Values.caddy.httpPort }}/internal/domains/allow
       }
     }
 
     http://:{{ .Values.caddy.httpPort }} {
+      @domain_allow path /internal/domains/allow
+      handle @domain_allow {
+        reverse_proxy {{ include "gesttalt.fullname" . }}-web:4000 {
+          header_up X-Forwarded-For {client_ip}
+          header_up X-Forwarded-Proto https
+        }
+      }
       redir https://{host}{uri} permanent
     }
 


### PR DESCRIPTION
## What changed

- Route Caddy's on-demand certificate authorization request through its local HTTP listener.
- Forward the request to the internal Gesttalt web Service with the HTTPS forwarding header Phoenix requires.
- Add a production chart assertion for this authorization path.

## Root cause

After the proxy was separated from the application pod, Caddy called the authorization endpoint directly over HTTP. Phoenix redirected that request to the public HTTPS host, and Caddy correctly refused to follow a redirect while deciding whether to issue a certificate. The result was a failed certificate handshake for public traffic.

## Approach

The local Caddy listener now proxies only the authorization endpoint to the internal web Service with an explicit forwarded HTTPS scheme. All other HTTP requests keep their existing permanent redirect behavior.

## Impact

On-demand certificate authorization works with the separate proxy and application deployments, restoring public traffic.

## Validation

- `helm lint deploy/helm/gesttalt --values deploy/values-production.yaml`
- Rendered the production chart and asserted the authorization configuration.
- Validated the rendered Caddyfile with the live Caddy binary in the production cluster.
