### PR TITLE
feat(gesttalt): add short notes

### DIFF
--- a/assets/css/routes/admin-content.css
+++ b/assets/css/routes/admin-content.css
@@ -1,4 +1,9 @@
 #admin-content {
+  & > #page-heading > [data-part="actions"] {
+    display: flex;
+    gap: 0.5rem;
+  }
+
   & > [data-part="list"] {
     & > [data-part="empty"] {
       color: var(--muted);

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -71,6 +71,8 @@ config :gesttalt, GesttaltWeb.Endpoint,
       ~r"priv/gettext/.*\.po$"E,
       # Changelog entries
       ~r"priv/changelog/.*\.md$"E,
+      # Built-in publication themes
+      ~r"priv/themes/.*\.(liquid|css)$"E,
       # Router, Controllers, LiveViews and LiveComponents
       ~r"lib/gesttalt_web/router\.ex$"E,
       ~r"lib/gesttalt_web/(controllers|live|components)/.*\.(ex|heex)$"E

--- a/lib/gesttalt/mcp.ex
+++ b/lib/gesttalt/mcp.ex
@@ -406,16 +406,20 @@ defmodule Gesttalt.MCP do
 
   defp tools do
     [
-      tool("list_content", "List every post and page for the authenticated publication", %{}),
-      tool("get_content", "Get one post or page", %{id: integer_schema()}),
+      tool(
+        "list_content",
+        "List every post, page, and note for the authenticated publication",
+        %{}
+      ),
+      tool("get_content", "Get one post, page, or note", %{id: integer_schema()}),
       tool(
         "create_content",
-        "Create a draft or published post or page",
-        content_schema(["title", "body"])
+        "Create a draft or published post, page, or short note. Notes only require body text and are limited to 500 characters.",
+        content_schema(["body"])
       ),
       tool(
         "update_content",
-        "Update a post or page",
+        "Update a post, page, or note",
         Map.put(
           content_schema([]),
           :properties,
@@ -423,11 +427,11 @@ defmodule Gesttalt.MCP do
         )
         |> Map.put(:required, ["id"])
       ),
-      tool("publish_content", "Publish a post or page", %{id: integer_schema()}),
-      tool("unpublish_content", "Move a published post or page back to drafts", %{
+      tool("publish_content", "Publish a post, page, or note", %{id: integer_schema()}),
+      tool("unpublish_content", "Move a published post, page, or note back to drafts", %{
         id: integer_schema()
       }),
-      tool("delete_content", "Permanently delete a post or page", %{id: integer_schema()}),
+      tool("delete_content", "Permanently delete a post, page, or note", %{id: integer_schema()}),
       tool("list_media", "List every image in the publication media library", %{}),
       tool(
         "upload_media",
@@ -642,7 +646,7 @@ defmodule Gesttalt.MCP do
         excerpt: string_schema(),
         tags: %{type: "array", items: string_schema()},
         body: string_schema(),
-        kind: %{type: "string", enum: ["post", "page"]},
+        kind: %{type: "string", enum: ["post", "page", "note"]},
         status: %{type: "string", enum: ["draft", "published"]},
         published_at: %{type: "string", format: "date-time"}
       },

--- a/lib/gesttalt/open_graph.ex
+++ b/lib/gesttalt/open_graph.ex
@@ -198,8 +198,7 @@ defmodule Gesttalt.OpenGraph do
     date =
       if published_at, do: Calendar.strftime(published_at, "%B %-d, %Y"), else: ""
 
-    minutes = Post.reading_time(post)
-    String.trim("#{date} · #{minutes} min read", " · ")
+    date
   end
 
   defp post_meta(:page, %Post{} = post) do

--- a/lib/gesttalt/open_graph/card.ex
+++ b/lib/gesttalt/open_graph/card.ex
@@ -27,7 +27,7 @@ defmodule Gesttalt.OpenGraph.Card do
     * `:eyebrow` - small label above the title (usually the publication name)
     * `:title` - the primary heading
     * `:subtitle` - supporting line below the title (may be empty)
-    * `:meta` - footer metadata line, e.g. date and reading time (may be empty)
+    * `:meta` - footer metadata line, e.g. publication date (may be empty)
   """
   @spec html(map()) :: String.t()
   def html(%{variables: variables} = assigns) do

--- a/lib/gesttalt/publishing.ex
+++ b/lib/gesttalt/publishing.ex
@@ -33,16 +33,22 @@ defmodule Gesttalt.Publishing do
 
   @doc "Lists one page of public articles and its pagination metadata."
   def paginate_published_posts(%Site{id: site_id}, page \\ 1) when is_integer(page) do
-    published_query(site_id, :post)
-    |> Flop.validate_and_run!(
-      %{page: max(page, 1), page_size: @published_posts_page_size},
-      for: Post
-    )
+    paginate_published(site_id, :post, page)
   end
 
   @doc "Lists public standalone pages for a site."
   def list_published_pages(%Site{id: site_id}) do
     published_query(site_id, :page) |> Repo.all()
+  end
+
+  @doc "Lists public short notes for a site, newest first."
+  def list_published_notes(%Site{id: site_id}) do
+    published_query(site_id, :note) |> Repo.all()
+  end
+
+  @doc "Lists one page of public short notes and its pagination metadata."
+  def paginate_published_notes(%Site{id: site_id}, page \\ 1) when is_integer(page) do
+    paginate_published(site_id, :note, page)
   end
 
   @doc "Fetches a site-owned post by its database identifier."
@@ -52,7 +58,7 @@ defmodule Gesttalt.Publishing do
   def get_post(%Site{id: site_id}, id), do: Repo.get_by(Post, id: id, site_id: site_id)
 
   @doc "Fetches a public post by kind and database identifier, or nil."
-  def get_published_post(%Site{id: site_id}, kind, id) when kind in [:post, :page] do
+  def get_published_post(%Site{id: site_id}, kind, id) when kind in [:post, :page, :note] do
     now = now()
 
     Post
@@ -67,7 +73,8 @@ defmodule Gesttalt.Publishing do
   end
 
   @doc "Fetches a public post by kind and slug."
-  def get_published_post_by_slug!(%Site{id: site_id}, kind, slug) when kind in [:post, :page] do
+  def get_published_post_by_slug!(%Site{id: site_id}, kind, slug)
+      when kind in [:post, :page, :note] do
     now = now()
 
     Post
@@ -118,6 +125,14 @@ defmodule Gesttalt.Publishing do
     |> where([post], post.status == :published)
     |> where([post], post.published_at <= ^now)
     |> order_by([post], desc: post.published_at, desc: post.id)
+  end
+
+  defp paginate_published(site_id, kind, page) do
+    published_query(site_id, kind)
+    |> Flop.validate_and_run!(
+      %{page: max(page, 1), page_size: @published_posts_page_size},
+      for: Post
+    )
   end
 
   defp key_for(attrs, key) do

--- a/lib/gesttalt/publishing/post.ex
+++ b/lib/gesttalt/publishing/post.ex
@@ -1,5 +1,5 @@
 defmodule Gesttalt.Publishing.Post do
-  @moduledoc "A draft or published article managed by Gesttalt."
+  @moduledoc "A draft or published article, page, or note managed by Gesttalt."
 
   use Ecto.Schema
   import Ecto.Changeset
@@ -22,7 +22,7 @@ defmodule Gesttalt.Publishing.Post do
     field :tags, {:array, :string}, default: []
     field :body, :string
     field :status, Ecto.Enum, values: @statuses, default: :draft
-    field :kind, Ecto.Enum, values: [:post, :page], default: :post
+    field :kind, Ecto.Enum, values: [:post, :page, :note], default: :post
     field :published_at, :utc_datetime
 
     belongs_to :site, Site
@@ -32,7 +32,7 @@ defmodule Gesttalt.Publishing.Post do
 
   @doc false
   def changeset(post, attrs) do
-    attrs = maybe_put_slug(post, attrs)
+    attrs = attrs |> maybe_fill_note_fields(post) |> then(&maybe_put_slug(post, &1))
 
     post
     |> cast(attrs, [
@@ -48,6 +48,7 @@ defmodule Gesttalt.Publishing.Post do
     ])
     |> validate_required([:site_id, :title, :slug, :body, :kind, :status])
     |> validate_length(:title, max: 160)
+    |> validate_note_length()
     |> validate_length(:slug, max: 180)
     |> validate_format(:slug, ~r/^[a-z0-9]+(?:-[a-z0-9]+)*$/,
       message: "may contain lowercase letters, numbers, and hyphens"
@@ -73,17 +74,6 @@ defmodule Gesttalt.Publishing.Post do
 
   def published?(_post), do: false
 
-  @doc "Returns a conservative reading time in minutes."
-  def reading_time(%__MODULE__{body: body}) do
-    body
-    |> String.split(~r/\s+/, trim: true)
-    |> length()
-    |> Kernel./(220)
-    |> Float.ceil()
-    |> trunc()
-    |> max(1)
-  end
-
   defp maybe_put_slug(post, attrs) do
     slug = value(attrs, :slug)
     title = value(attrs, :title)
@@ -95,12 +85,49 @@ defmodule Gesttalt.Publishing.Post do
     end
   end
 
+  defp maybe_fill_note_fields(attrs, post) do
+    if value(attrs, :kind) in [:note, "note"] do
+      attrs
+      |> maybe_put_note_title(post)
+      |> maybe_put_note_slug(post)
+    else
+      attrs
+    end
+  end
+
+  defp maybe_put_note_title(attrs, %__MODULE__{title: nil}) do
+    if blank?(value(attrs, :title)), do: put_value(attrs, :title, "Note"), else: attrs
+  end
+
+  defp maybe_put_note_title(attrs, _post), do: attrs
+
+  defp maybe_put_note_slug(attrs, %__MODULE__{slug: nil}) do
+    if blank?(value(attrs, :slug)),
+      do: put_value(attrs, :slug, "note-#{Ecto.UUID.generate()}"),
+      else: attrs
+  end
+
+  defp maybe_put_note_slug(attrs, _post), do: attrs
+
   defp put_slug(attrs, slug) do
     key = if Enum.any?(Map.keys(attrs), &is_binary/1), do: "slug", else: :slug
     Map.put(attrs, key, slug)
   end
 
+  defp put_value(attrs, key, value) do
+    target_key = if Enum.any?(Map.keys(attrs), &is_binary/1), do: Atom.to_string(key), else: key
+    Map.put(attrs, target_key, value)
+  end
+
   defp value(attrs, key), do: Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+
+  defp blank?(value), do: value in [nil, ""]
+
+  defp validate_note_length(changeset) do
+    if get_field(changeset, :kind) == :note,
+      do: validate_length(changeset, :body, min: 1, max: 500),
+      else: changeset
+  end
 
   defp slugify(title) do
     title

--- a/lib/gesttalt/publishing/post_json.ex
+++ b/lib/gesttalt/publishing/post_json.ex
@@ -23,5 +23,6 @@ defmodule Gesttalt.Publishing.PostJSON do
 
   defp url(%Post{status: :published, kind: :post, slug: slug}), do: "/blog/#{slug}/"
   defp url(%Post{status: :published, kind: :page, slug: slug}), do: "/#{slug}/"
+  defp url(%Post{status: :published, kind: :note, id: id}), do: "/notes/#{id}/"
   defp url(_post), do: nil
 end

--- a/lib/gesttalt/themes/renderer.ex
+++ b/lib/gesttalt/themes/renderer.ex
@@ -4,7 +4,6 @@ defmodule Gesttalt.Themes.Renderer do
   alias Gesttalt.Markdown
   alias Gesttalt.OpenGraph
   alias Gesttalt.Photography.Photo
-  alias Gesttalt.Publishing
   alias Gesttalt.Publishing.Post
   alias Gesttalt.Sites.{Image, Site, Theme, ThemeDefaults}
   alias Gesttalt.Themes.Variables
@@ -20,15 +19,17 @@ defmodule Gesttalt.Themes.Renderer do
       ) do
     archive? = Keyword.get(options, :archive, false)
     archive_path = Keyword.get(options, :archive_path, "/blog")
+    collection = Keyword.get(options, :collection, :posts)
 
     context =
       base_context(site, theme, pages, og)
       |> Map.put("posts", Enum.map(posts, &post_context(&1, og)))
       |> Map.put("archive_url", archive_path)
       |> Map.put("is_archive", archive?)
+      |> Map.put("is_notes", collection == :notes)
       |> Map.put("pagination", pagination_context(pagination, length(posts), archive_path))
 
-    render(theme.index_template, context, index_metadata(site, og, archive?))
+    render(theme.index_template, context, index_metadata(site, og, archive?, collection))
   end
 
   def render_article(%Site{} = site, %Theme{} = theme, %Post{} = post, pages, og \\ nil) do
@@ -115,7 +116,16 @@ defmodule Gesttalt.Themes.Renderer do
     end
   end
 
-  defp index_metadata(site, og, true) do
+  defp index_metadata(site, og, true, :notes) do
+    %{
+      type: "website",
+      title: "Notes · #{site.name}",
+      description: site.description || site.tagline || "",
+      image: home_og_image(site, og)
+    }
+  end
+
+  defp index_metadata(site, og, true, _collection) do
     %{
       type: "website",
       title: "Writing · #{site.name}",
@@ -124,7 +134,7 @@ defmodule Gesttalt.Themes.Renderer do
     }
   end
 
-  defp index_metadata(site, og, false) do
+  defp index_metadata(site, og, false, _collection) do
     %{
       type: "website",
       title: site.name,
@@ -217,10 +227,9 @@ defmodule Gesttalt.Themes.Renderer do
       "body_html" => post.body |> Markdown.to_html() |> Phoenix.HTML.safe_to_string(),
       "kind" => to_string(post.kind),
       "og_image" => post_og_image(post, og),
-      "url" => if(post.kind == :page, do: "/#{post.slug}/", else: "/blog/#{post.slug}/"),
+      "url" => publication_url(post),
       "published_at" => DateTime.to_iso8601(published_at),
-      "published_on" => Calendar.strftime(published_at, "%B %-d, %Y"),
-      "reading_time" => Publishing.Post.reading_time(post)
+      "published_on" => Calendar.strftime(published_at, "%B %-d, %Y")
     }
   end
 
@@ -236,6 +245,10 @@ defmodule Gesttalt.Themes.Renderer do
       "published_on" => Calendar.strftime(published_at, "%B %-d, %Y")
     }
   end
+
+  defp publication_url(%{kind: :post, slug: slug}), do: "/blog/#{slug}/"
+  defp publication_url(%{kind: :page, slug: slug}), do: "/#{slug}/"
+  defp publication_url(%{kind: :note, id: id}), do: "/notes/#{id}/"
 
   defp escape(value),
     do: value |> then(&(&1 || "")) |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()

--- a/lib/gesttalt_web/api/schemas.ex
+++ b/lib/gesttalt_web/api/schemas.ex
@@ -13,7 +13,7 @@ defmodule GesttaltWeb.API.Schemas.Post do
       excerpt: %OpenApiSpex.Schema{type: :string, nullable: true},
       tags: %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :string}},
       body: %OpenApiSpex.Schema{type: :string},
-      kind: %OpenApiSpex.Schema{type: :string, enum: ["post", "page"]},
+      kind: %OpenApiSpex.Schema{type: :string, enum: ["post", "page", "note"]},
       status: %OpenApiSpex.Schema{type: :string, enum: ["draft", "published"]},
       published_at: %OpenApiSpex.Schema{type: :string, format: :date_time, nullable: true},
       url: %OpenApiSpex.Schema{type: :string, nullable: true}
@@ -36,7 +36,7 @@ defmodule GesttaltWeb.API.Schemas.PostParams do
       excerpt: %OpenApiSpex.Schema{type: :string},
       tags: %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :string}},
       body: %OpenApiSpex.Schema{type: :string},
-      kind: %OpenApiSpex.Schema{type: :string, enum: ["post", "page"]},
+      kind: %OpenApiSpex.Schema{type: :string, enum: ["post", "page", "note"]},
       status: %OpenApiSpex.Schema{type: :string, enum: ["draft", "published"]},
       published_at: %OpenApiSpex.Schema{type: :string, format: :date_time}
     },

--- a/lib/gesttalt_web/controllers/admin_controller.ex
+++ b/lib/gesttalt_web/controllers/admin_controller.ex
@@ -8,7 +8,13 @@ defmodule GesttaltWeb.AdminController do
 
   def index(conn, _params) do
     site = current_site(conn)
-    render(conn, :index, page_title: "Editor", posts: Publishing.list_posts(site), site: site)
+
+    render(conn, :index,
+      page_title: "Editor",
+      posts: Publishing.list_posts(site),
+      public_origin: public_origin(conn),
+      site: site
+    )
   end
 
   def analytics(conn, params) do
@@ -26,6 +32,10 @@ defmodule GesttaltWeb.AdminController do
 
   def new(conn, _params),
     do: render_form(conn, Publishing.change_post(%Post{}), "New post", ~p"/admin/posts")
+
+  def new_note(conn, _params),
+    do:
+      render_form(conn, Publishing.change_post(%Post{kind: :note}), "New note", ~p"/admin/posts")
 
   def create(conn, %{"post" => attrs}) do
     case Publishing.create_post(current_site(conn), attrs) do
@@ -92,5 +102,10 @@ defmodule GesttaltWeb.AdminController do
   defp current_site(conn) do
     {:ok, site} = Sites.ensure_site_for_user(conn.assigns.current_scope.user)
     site
+  end
+
+  defp public_origin(conn) do
+    port = if conn.port in [80, 443], do: "", else: ":#{conn.port}"
+    "#{conn.scheme}://#{conn.host}#{port}"
   end
 end

--- a/lib/gesttalt_web/controllers/admin_html.ex
+++ b/lib/gesttalt_web/controllers/admin_html.ex
@@ -12,9 +12,18 @@ defmodule GesttaltWeb.AdminHTML do
     end
   end
 
-  def public_url(site, post) do
+  def public_url(origin, site, post) do
     domain = Enum.find(site.domains, &(&1.status == :active))
-    path = if post.kind == :post, do: "/blog/#{post.slug}/", else: "/#{post.slug}/"
-    if domain, do: "https://#{domain.hostname}#{path}", else: path
+
+    path =
+      case post.kind do
+        :post -> "/blog/#{post.slug}/"
+        :note -> "/notes/#{post.id}/"
+        :page -> "/#{post.slug}/"
+      end
+
+    if domain,
+      do: "#{origin |> URI.parse() |> Map.put(:host, domain.hostname) |> URI.to_string()}#{path}",
+      else: path
   end
 end

--- a/lib/gesttalt_web/controllers/admin_html/edit.html.heex
+++ b/lib/gesttalt_web/controllers/admin_html/edit.html.heex
@@ -4,7 +4,11 @@
       <p data-part="eyebrow">Publishing desk</p>
       <h1 data-part="title">{@page_title}</h1>
       <p data-part="description">
-        Markdown is supported. The slug becomes the post's permanent address.
+        {if @post.kind == :note do
+          "Write up to 500 characters. Markdown is supported."
+        else
+          "Markdown is supported. The slug becomes the post's permanent address."
+        end}
       </p>
     </header>
 
@@ -15,7 +19,7 @@
       method={@form_method}
       data-part="form"
     >
-      <div class="field" data-part="field">
+      <div :if={@post.kind != :note} class="field" data-part="field">
         <label for={form[:title].id}>Title</label>
         <input
           type="text"
@@ -28,7 +32,7 @@
         <p :for={error <- form[:title].errors} class="field-error">{translate_error(error)}</p>
       </div>
 
-      <div class="field" data-part="field">
+      <div :if={@post.kind != :note} class="field" data-part="field">
         <label for={form[:slug].id}>Slug</label>
         <input
           type="text"
@@ -40,7 +44,7 @@
         <p :for={error <- form[:slug].errors} class="field-error">{translate_error(error)}</p>
       </div>
 
-      <div class="field" data-part="field">
+      <div :if={@post.kind != :note} class="field" data-part="field">
         <label for={form[:excerpt].id}>Excerpt</label>
         <textarea
           id={form[:excerpt].id}
@@ -52,19 +56,21 @@
       </div>
 
       <div class="field" data-part="field">
-        <label for={form[:body].id}>Article</label>
+        <label for={form[:body].id}>{if(@post.kind == :note, do: "Note", else: "Article")}</label>
         <textarea
           id={form[:body].id}
           name={form[:body].name}
           rows="22"
           class="editor-body"
+          maxlength={if(@post.kind == :note, do: "500")}
           required
         >{form[:body].value}</textarea>
         <p :for={error <- form[:body].errors} class="field-error">{translate_error(error)}</p>
       </div>
 
+      <input :if={@post.kind == :note} type="hidden" name={form[:kind].name} value="note" />
       <div class="form-grid" data-part="field-grid">
-        <div class="field" data-part="field">
+        <div :if={@post.kind != :note} class="field" data-part="field">
           <label for={form[:kind].id}>Type</label>
           <select id={form[:kind].id} name={form[:kind].name}><option
             value="post"
@@ -73,6 +79,8 @@
             Post
           </option><option value="page" selected={to_string(form[:kind].value) == "page"}>
             Page
+          </option><option value="note" selected={to_string(form[:kind].value) == "note"}>
+            Note
           </option></select>
         </div>
         <div class="field" data-part="field">
@@ -98,13 +106,16 @@
       </div>
 
       <div class="form-actions" data-part="actions">
-        <button class="button button--primary" type="submit">Save post</button>
+        <button class="button button--primary" type="submit">Save {if(@post.kind == :note,
+          do: "note",
+          else: "post"
+        )}</button>
         <a class="button" href={~p"/admin/"}>Cancel</a>
       </div>
     </.form>
 
     <section :if={@post.id} data-part="danger-zone">
-      <h2>Delete post</h2>
+      <h2>Delete {if(@post.kind == :note, do: "note", else: "post")}</h2>
       <p>This cannot be undone.</p>
       <form action={~p"/admin/posts/#{@post}"} method="post">
         <input type="hidden" name="_method" value="delete" />

--- a/lib/gesttalt_web/controllers/admin_html/index.html.heex
+++ b/lib/gesttalt_web/controllers/admin_html/index.html.heex
@@ -34,9 +34,10 @@
             )}
           </p>
         </div><div data-part="actions">
-          <a :if={Gesttalt.Publishing.Post.published?(post)} href={public_url(@public_origin, @site, post)}>View</a><a href={
-            ~p"/admin/posts/#{post}/edit"
-          }>Edit</a><form
+          <a
+            :if={Gesttalt.Publishing.Post.published?(post)}
+            href={public_url(@public_origin, @site, post)}
+          >View</a><a href={~p"/admin/posts/#{post}/edit"}>Edit</a><form
             :if={post.status == :draft}
             action={~p"/admin/posts/#{post}/publish"}
             method="post"

--- a/lib/gesttalt_web/controllers/admin_html/index.html.heex
+++ b/lib/gesttalt_web/controllers/admin_html/index.html.heex
@@ -5,7 +5,13 @@
         <p data-part="eyebrow">Publishing desk</p><h1 data-part="title">Content</h1><p data-part="description">
           Posts and pages for <strong>{@site.name}</strong>.
         </p>
-      </div><a data-part="action" class="button button--primary" href={~p"/admin/posts/new"}>New post</a>
+      </div><div data-part="actions">
+        <a class="button" href={~p"/admin/notes/new"}>New note</a><a
+          data-part="action"
+          class="button button--primary"
+          href={~p"/admin/posts/new"}
+        >New post</a>
+      </div>
     </header>
     <section data-part="list" aria-label="Content">
       <div :if={@posts == []} data-part="empty">
@@ -22,10 +28,13 @@
           </div><h2 data-part="title">
             <a href={~p"/admin/posts/#{post}/edit"}>{post.title}</a>
           </h2><p data-part="path">
-            /{if(post.kind == :post, do: "blog/", else: "")}{post.slug}
+            {if(post.kind == :note,
+              do: "/notes/#{post.id}",
+              else: "/#{if(post.kind == :post, do: "blog/", else: "")}#{post.slug}"
+            )}
           </p>
         </div><div data-part="actions">
-          <a :if={Gesttalt.Publishing.Post.published?(post)} href={public_url(@site, post)}>View</a><a href={
+          <a :if={Gesttalt.Publishing.Post.published?(post)} href={public_url(@public_origin, @site, post)}>View</a><a href={
             ~p"/admin/posts/#{post}/edit"
           }>Edit</a><form
             :if={post.status == :draft}

--- a/lib/gesttalt_web/controllers/feed_controller.ex
+++ b/lib/gesttalt_web/controllers/feed_controller.ex
@@ -5,7 +5,34 @@ defmodule GesttaltWeb.FeedController do
   alias Gesttalt.Publishing
 
   def atom(%{assigns: %{current_site: site}} = conn, _params) do
-    posts = Publishing.list_published_posts(site)
+    render_atom(
+      conn,
+      site,
+      Publishing.list_published_posts(site),
+      "#{site.name}",
+      "/blog/atom.xml"
+    )
+  end
+
+  def notes_atom(%{assigns: %{current_site: site}} = conn, _params) do
+    render_atom(
+      conn,
+      site,
+      Publishing.list_published_notes(site),
+      "Notes from #{site.name}",
+      "/notes/atom.xml"
+    )
+  end
+
+  def rss(%{assigns: %{current_site: site}} = conn, _params) do
+    render_rss(conn, site, Publishing.list_published_posts(site), site.name)
+  end
+
+  def notes_rss(%{assigns: %{current_site: site}} = conn, _params) do
+    render_rss(conn, site, Publishing.list_published_notes(site), "Notes from #{site.name}")
+  end
+
+  defp render_atom(conn, site, posts, title, self_path) do
     updated_at = latest_updated_at(posts, site)
     entries = Enum.map_join(posts, "\n", &atom_entry(&1, conn))
 
@@ -13,10 +40,10 @@ defmodule GesttaltWeb.FeedController do
     <?xml version="1.0" encoding="utf-8"?>
     <feed xmlns="http://www.w3.org/2005/Atom">
       <id>#{origin(conn)}/</id>
-      <title>#{escape(site.name)}</title>
+      <title>#{escape(title)}</title>
       <subtitle>#{escape(site.tagline || "")}</subtitle>
       <updated>#{DateTime.to_iso8601(updated_at)}</updated>
-      <link href="#{origin(conn)}/blog/atom.xml" rel="self" type="application/atom+xml" />
+      <link href="#{origin(conn)}#{self_path}" rel="self" type="application/atom+xml" />
       <link href="#{origin(conn)}/" />
       #{entries}
     </feed>
@@ -25,17 +52,14 @@ defmodule GesttaltWeb.FeedController do
     conn |> put_resp_content_type("application/atom+xml") |> send_resp(200, feed)
   end
 
-  def rss(%{assigns: %{current_site: site}} = conn, _params) do
-    items =
-      site
-      |> Publishing.list_published_posts()
-      |> Enum.map_join("\n", &rss_item(&1, conn))
+  defp render_rss(conn, site, posts, title) do
+    items = Enum.map_join(posts, "\n", &rss_item(&1, conn))
 
     feed = """
     <?xml version="1.0" encoding="utf-8"?>
     <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
       <channel>
-        <title>#{escape(site.name)}</title>
+        <title>#{escape(title)}</title>
         <link>#{origin(conn)}/</link>
         <description>#{escape(site.tagline || "")}</description>
         <atom:link href="#{origin(conn)}#{conn.request_path}" rel="self" type="application/rss+xml" />
@@ -84,6 +108,7 @@ defmodule GesttaltWeb.FeedController do
     end)
   end
 
+  defp post_url(%{kind: :note, id: id}, conn), do: "#{origin(conn)}/notes/#{id}/"
   defp post_url(post, conn), do: "#{origin(conn)}/blog/#{post.slug}/"
 
   defp origin(conn),

--- a/lib/gesttalt_web/controllers/site_controller.ex
+++ b/lib/gesttalt_web/controllers/site_controller.ex
@@ -108,6 +108,30 @@ defmodule GesttaltWeb.SiteController do
     end
   end
 
+  def notes(%{assigns: %{current_site: site}} = conn, params) do
+    page = page_number(params)
+    {notes, pagination} = Publishing.paginate_published_notes(site, page)
+    last_page = max(pagination.total_pages, 1)
+
+    if page > last_page do
+      redirect(conn, to: notes_path(last_page))
+    else
+      render_notes(conn, site, notes, pagination)
+    end
+  end
+
+  def notes_markdown(%{assigns: %{current_site: site}} = conn, params) do
+    page = page_number(params)
+    {notes, pagination} = Publishing.paginate_published_notes(site, page)
+    last_page = max(pagination.total_pages, 1)
+
+    if page > last_page do
+      redirect(conn, to: notes_markdown_path(last_page))
+    else
+      markdown(conn, markdown_notes(site, notes, pagination))
+    end
+  end
+
   defp render_archive(conn, site, posts, pagination) do
     if markdown_requested?(conn) do
       markdown(conn, markdown_archive(site, posts, pagination))
@@ -129,6 +153,28 @@ defmodule GesttaltWeb.SiteController do
     end
   end
 
+  defp render_notes(conn, site, notes, pagination) do
+    if markdown_requested?(conn) do
+      markdown(conn, markdown_notes(site, notes, pagination))
+    else
+      og = og_context(conn, site)
+
+      render_theme(conn, site, fn ->
+        Renderer.render_index(
+          site,
+          site.theme,
+          notes,
+          Publishing.list_published_pages(site),
+          pagination,
+          og,
+          archive: true,
+          archive_path: "/notes",
+          collection: :notes
+        )
+      end)
+    end
+  end
+
   def article(%{assigns: %{current_site: site}} = conn, %{"slug" => slug}) do
     {slug, markdown?} = markdown_path?(slug, conn)
     post = Publishing.get_published_post_by_slug!(site, :post, slug)
@@ -141,6 +187,20 @@ defmodule GesttaltWeb.SiteController do
       render_theme(conn, site, fn ->
         Renderer.render_article(site, site.theme, post, Publishing.list_published_pages(site), og)
       end)
+    end
+  end
+
+  def note(%{assigns: %{current_site: site}} = conn, %{"id" => id}) do
+    note = Publishing.get_published_post(site, :note, id)
+
+    if note do
+      og = og_context(conn, site)
+
+      render_theme(conn, site, fn ->
+        Renderer.render_article(site, site.theme, note, Publishing.list_published_pages(site), og)
+      end)
+    else
+      send_resp(conn, :not_found, "Note not found")
     end
   end
 
@@ -196,7 +256,8 @@ defmodule GesttaltWeb.SiteController do
       markdown_index(
         site,
         Publishing.list_published_pages(site),
-        Publishing.list_published_posts(site)
+        Publishing.list_published_posts(site),
+        Publishing.list_published_notes(site)
       )
     )
   end
@@ -323,6 +384,12 @@ defmodule GesttaltWeb.SiteController do
   defp archive_markdown_path(1), do: "/blog.md"
   defp archive_markdown_path(page), do: "/blog.md?page=#{page}"
 
+  defp notes_path(1), do: "/notes"
+  defp notes_path(page), do: "/notes?page=#{page}"
+
+  defp notes_markdown_path(1), do: "/notes.md"
+  defp notes_markdown_path(page), do: "/notes.md?page=#{page}"
+
   defp markdown_home(site, posts) do
     [
       "# #{site.name}",
@@ -341,6 +408,19 @@ defmodule GesttaltWeb.SiteController do
     [
       "# Writing from #{site.name}",
       markdown_post_links(nil, posts),
+      "Page #{page} of #{max(pages, 1)}."
+    ]
+    |> Enum.reject(&blank_markdown?/1)
+    |> Enum.join("\n\n")
+  end
+
+  defp markdown_notes(site, notes, pagination) do
+    page = Map.get(pagination, :current_page, 1)
+    pages = Map.get(pagination, :total_pages, 1)
+
+    [
+      "# Notes from #{site.name}",
+      Enum.map_join(notes, "\n\n", fn note -> "- [#{note.body}](/notes/#{note.id})" end),
       "Page #{page} of #{max(pages, 1)}."
     ]
     |> Enum.reject(&blank_markdown?/1)
@@ -369,13 +449,14 @@ defmodule GesttaltWeb.SiteController do
     |> Enum.join("\n\n")
   end
 
-  defp markdown_index(site, pages, posts) do
+  defp markdown_index(site, pages, posts, notes) do
     document =
       [
         "# #{site.name}",
         site.tagline,
         "## Pages\n\n" <> markdown_link_list(pages, &"/#{&1.slug}.md"),
         "## Writing\n\n" <> markdown_link_list(posts, &"/blog/#{&1.slug}.md"),
+        "## Notes\n\n" <> markdown_link_list(notes, &"/notes/#{&1.id}"),
         "## Other\n\n- [Photography](/photography.md)"
       ]
       |> Enum.reject(&blank_markdown?/1)

--- a/lib/gesttalt_web/router.ex
+++ b/lib/gesttalt_web/router.ex
@@ -120,6 +120,7 @@ defmodule GesttaltWeb.Router do
     get "/", AdminController, :index
     get "/analytics", AdminController, :analytics
     get "/posts/new", AdminController, :new
+    get "/notes/new", AdminController, :new_note
     post "/posts", AdminController, :create
     get "/posts/:id/edit", AdminController, :edit
     put "/posts/:id", AdminController, :update
@@ -225,6 +226,9 @@ defmodule GesttaltWeb.Router do
     get "/blog/feed.xml", FeedController, :rss
     get "/blog/rss.xml", FeedController, :rss
     get "/blog/atom.xml", FeedController, :atom
+    get "/notes/feed.xml", FeedController, :notes_rss
+    get "/notes/rss.xml", FeedController, :notes_rss
+    get "/notes/atom.xml", FeedController, :notes_atom
   end
 
   scope "/", GesttaltWeb do
@@ -243,6 +247,9 @@ defmodule GesttaltWeb.Router do
     get "/photography", SiteController, :photography
     get "/blog", SiteController, :archive
     get "/blog/:slug", SiteController, :article
+    get "/notes.md", SiteController, :notes_markdown
+    get "/notes", SiteController, :notes
+    get "/notes/:id", SiteController, :note
     get "/media/:id/:filename", SiteController, :media
     get "/og-image", OpenGraphController, :show
     get "/:slug", SiteController, :page

--- a/mix.exs
+++ b/mix.exs
@@ -99,7 +99,7 @@ defmodule Gesttalt.MixProject do
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
-      "assets.setup": ["esbuild.install --if-missing"],
+      "assets.setup": ["esbuild.install --if-missing", "cmd npm ci --prefix assets"],
       "assets.build": ["compile", "esbuild gesttalt"],
       "assets.deploy": [
         "esbuild gesttalt --minify",

--- a/priv/changelog/2026-08-10-short-notes.md
+++ b/priv/changelog/2026-08-10-short-notes.md
@@ -1,0 +1,9 @@
+%{
+  title: "Publish short notes",
+  summary: "Share brief updates with their own pages and feeds."
+}
+---
+
+Gesttalt now supports short notes for updates that do not need the shape of a full article. Create and publish notes from the dashboard, application programming interface, or Model Context Protocol server.
+
+Each note has a permanent address and appears in dedicated [Really Simple Syndication](https://www.rssboard.org/rss-specification) and [Atom](https://www.rfc-editor.org/rfc/rfc4287) feeds, so readers can follow brief updates separately from longer writing.

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -146,4 +146,23 @@ if bootstrap_email do
         })
     end)
   end
+
+  if Application.get_env(:gesttalt, :seed_demo) and Publishing.list_published_notes(site) == [] do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    for {body, minutes_ago} <- [
+          {"Shipping the short notes feed today. It feels good to give small updates their own home.",
+           20},
+          {"A clean desk is sometimes just a browser tab away.", 95},
+          {"The best publishing tools leave more room for noticing.", 240}
+        ] do
+      {:ok, _note} =
+        Publishing.create_post(site, %{
+          body: body,
+          status: :published,
+          kind: :note,
+          published_at: DateTime.add(now, -minutes_ago * 60, :second)
+        })
+    end
+  end
 end

--- a/priv/themes/paper/article.liquid
+++ b/priv/themes/paper/article.liquid
@@ -11,20 +11,20 @@
     <meta property="og:image" content="{{ post.og_image }}">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="{{ post.og_image }}">
-    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="/blog/feed.xml">
-    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="/blog/atom.xml">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="{% if post.kind == 'note' %}/notes/feed.xml{% else %}/blog/feed.xml{% endif %}">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="{% if post.kind == 'note' %}/notes/atom.xml{% else %}/blog/atom.xml{% endif %}">
     <style>{{ stylesheet }}</style>
   </head>
   <body>
     <header class="site-header">
       <div class="container header-inner">
         <div class="site-identity"><a class="site-title" href="/">{{ site.name }}</a><span class="site-tagline">{{ site.tagline }}</span></div>
-        <nav><a href="/">Writing</a><a href="/photography">Photography</a>{% for page in pages %}<a href="{{ page.url }}">{{ page.title }}</a>{% endfor %}</nav>
+        <nav><a href="/">Writing</a><a href="/notes">Notes</a><a href="/photography">Photography</a>{% for page in pages %}<a href="{{ page.url }}">{{ page.title }}</a>{% endfor %}</nav>
       </div>
     </header>
     <main class="container page">
       <article>
-        <header class="article-header"><p class="section-label">{{ post.published_on }} · {{ post.reading_time }} min read</p><h1>{{ post.title }}</h1><p class="lede">{{ post.excerpt }}</p></header>
+        <header class="article-header"><p class="section-label">{{ post.published_on }}</p><h1>{{ post.title }}</h1><p class="lede">{{ post.excerpt }}</p></header>
         <div class="prose">{{ post.body_html }}</div>
       </article>
     </main>

--- a/priv/themes/paper/index.liquid
+++ b/priv/themes/paper/index.liquid
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ site.name }}</title>
+    <title>{% if is_notes %}Notes · {% endif %}{{ site.name }}</title>
     <meta name="description" content="{{ site.tagline }}">
     <meta property="og:type" content="website">
     <meta property="og:title" content="{{ site.name }}">
@@ -11,11 +11,11 @@
     <meta property="og:image" content="{{ og_image }}">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="{{ og_image }}">
-    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="/blog/feed.xml">
-    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="/blog/atom.xml">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="{% if is_notes %}/notes/feed.xml{% else %}/blog/feed.xml{% endif %}">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="{% if is_notes %}/notes/atom.xml{% else %}/blog/atom.xml{% endif %}">
     <style>{{ stylesheet }}</style>
   </head>
-  <body id="{% if is_archive %}site-blog{% else %}site-home{% endif %}">
+  <body id="{% if is_notes %}site-notes{% elsif is_archive %}site-blog{% else %}site-home{% endif %}">
     <header class="site-header">
       <div class="container header-inner">
         <div class="site-identity">
@@ -24,6 +24,7 @@
         </div>
         <nav>
           <a href="/blog">Writing</a>
+          <a href="/notes">Notes</a>
           <a href="/photography">Photography</a>
           {% for page in pages %}<a href="{{ page.url }}">{{ page.title }}</a>{% endfor %}
         </nav>
@@ -31,20 +32,19 @@
     </header>
     <main class="container page">
       {% if site.has_description %}{% unless is_archive %}<section data-part="description" class="prose">{{ site.description_html }}</section>{% endunless %}{% endif %}
-      <p class="section-label">{% if is_archive %}Writing{% else %}Recent writing{% endif %}</p>
+      <p class="section-label">{% if is_notes %}Notes{% elsif is_archive %}Writing{% else %}Recent writing{% endif %}</p>
       <section class="posts-list">
         {% for post in posts %}
         <article class="post-row">
           <time datetime="{{ post.published_at }}">{{ post.published_on }}</time>
           <div class="post-copy">
-            <a class="post-link" href="{{ post.url }}">{{ post.title }}</a>
-            <p>{{ post.excerpt }}</p>
+            {% if is_notes %}<a class="note-link" href="{{ post.url }}">{{ post.body }}</a>{% else %}<a class="post-link" href="{{ post.url }}">{{ post.title }}</a><p>{{ post.excerpt }}</p>{% endif %}
           </div>
         </article>
         {% endfor %}
       </section>
       {% if pagination.total_pages > 1 %}
-      <nav id="posts-pagination" aria-label="Writing pages">
+      <nav id="posts-pagination" aria-label="{% if is_notes %}Notes{% else %}Writing{% endif %} pages">
         {% if pagination.previous_url %}<a data-part="previous" href="{{ pagination.previous_url }}">Newer posts</a>{% endif %}
         <span data-part="status">Page {{ pagination.current_page }} of {{ pagination.total_pages }}</span>
         {% if pagination.next_url %}<a data-part="next" href="{{ pagination.next_url }}">Older posts</a>{% endif %}
@@ -54,7 +54,7 @@
     </main>
     <footer id="site-footer">
       <div class="container" data-part="inner">
-        <span data-part="feeds"><a href="/blog/feed.xml">Really Simple Syndication</a> · <a href="/blog/atom.xml">Atom</a></span>
+        <span data-part="feeds">{% if is_notes %}<a href="/notes/feed.xml">Really Simple Syndication</a> · <a href="/notes/atom.xml">Atom</a>{% else %}<a href="/blog/feed.xml">Really Simple Syndication</a> · <a href="/blog/atom.xml">Atom</a>{% endif %}</span>
         <span data-part="powered-by">Powered by <a href="https://gesttalt.org">Gesttalt</a></span>
       </div>
     </footer>

--- a/priv/themes/paper/theme.css
+++ b/priv/themes/paper/theme.css
@@ -8,12 +8,14 @@ a:hover { color: var(--gesttalt-colors-primary); }
 .header-inner { align-items: flex-start; display: flex; flex-direction: column; gap: 1.5rem; }
 .site-identity { display: flex; flex-direction: column; }
 .site-title, nav a, .post-link { font-weight: var(--gesttalt-font-weights-bold); text-decoration: none; }
+.note-link { font-weight: var(--gesttalt-font-weights-body); text-decoration: none; }
 .site-tagline, time, .post-copy p, #site-footer { color: var(--gesttalt-colors-muted-text); }
 nav { display: flex; flex-wrap: wrap; gap: 1rem; }
 .page { padding-block: 2.5rem; }
 .section-label { color: var(--gesttalt-colors-muted-text); font-weight: 650; letter-spacing: .04em; margin: 0 0 1rem; }
 .posts-list { display: grid; }
 .post-row { display: grid; grid-template-columns: 11rem 1fr; gap: 1rem; padding: 1.25rem 0; border-bottom: 1px solid var(--gesttalt-colors-border); }
+.post-row:last-child { border-bottom: 0; }
 .post-copy { display: grid; gap: .25rem; }
 .post-copy p { margin: 0; }
 .article-header { border-bottom: 1px solid var(--gesttalt-colors-border); margin-bottom: 1.75rem; padding-bottom: 1.25rem; }
@@ -27,7 +29,7 @@ h1 { font-family: var(--gesttalt-fonts-heading); font-size: var(--gesttalt-font-
 .prose code { background: var(--gesttalt-colors-surface); font-family: var(--gesttalt-fonts-monospace); font-size: .9em; padding: .1rem .3rem; }
 .prose pre { background: var(--gesttalt-colors-surface); border: 1px solid var(--gesttalt-colors-border); overflow-x: auto; padding: 1rem; }
 .prose pre code { padding: 0; }
-#site-home, #site-blog {
+#site-home, #site-blog, #site-notes {
   & [data-part="description"] {
     border-bottom: 1px solid var(--gesttalt-colors-border);
     margin-bottom: 2.5rem;

--- a/test/gesttalt/changelog_test.exs
+++ b/test/gesttalt/changelog_test.exs
@@ -7,10 +7,10 @@ defmodule Gesttalt.ChangelogTest do
     entries = Changelog.list()
     [latest | _rest] = entries
 
-    assert latest.slug == "uniform-publication-type-size"
-    assert latest.published_on == ~D[2026-08-09]
-    assert latest.title == "Use one text size across built-in themes"
-    assert latest.summary =~ "Headings, introductory text"
+    assert latest.slug == "short-notes"
+    assert latest.published_on == ~D[2026-08-10]
+    assert latest.title == "Publish short notes"
+    assert latest.summary =~ "brief updates"
 
     assert entries ==
              Enum.sort_by(

--- a/test/gesttalt/open_graph/card_test.exs
+++ b/test/gesttalt/open_graph/card_test.exs
@@ -11,13 +11,13 @@ defmodule Gesttalt.OpenGraph.CardTest do
         eyebrow: "Field Notes",
         title: "A quiet place for lasting words",
         subtitle: "On writing that endures",
-        meta: "May 1, 2026 · 4 min read"
+        meta: "May 1, 2026"
       })
 
     assert html =~ "Field Notes"
     assert html =~ "A quiet place for lasting words"
     assert html =~ "On writing that endures"
-    assert html =~ "May 1, 2026 · 4 min read"
+    assert html =~ "May 1, 2026"
   end
 
   test "uses the theme's colors and fonts" do

--- a/test/gesttalt/publishing_test.exs
+++ b/test/gesttalt/publishing_test.exs
@@ -53,6 +53,53 @@ defmodule Gesttalt.PublishingTest do
     assert page.status == :draft
   end
 
+  test "creates a short note without a title or slug", %{site: site} do
+    assert {:ok, %Post{} = note} =
+             Publishing.create_post(site, %{body: "A small update.", kind: :note})
+
+    assert note.title == "Note"
+    assert note.slug =~ "note-"
+    assert note.kind == :note
+  end
+
+  test "limits notes to 500 characters", %{site: site} do
+    assert {:error, changeset} =
+             Publishing.create_post(site, %{body: String.duplicate("a", 501), kind: :note})
+
+    assert "should be at most 500 character(s)" in errors_on(changeset).body
+  end
+
+  test "lists only published notes", %{site: site} do
+    published = post_fixture(%{site: site, kind: :note, status: :published, body: "Public"})
+    _draft = post_fixture(%{site: site, kind: :note, body: "Draft"})
+    _post = post_fixture(%{site: site, status: :published})
+
+    assert Publishing.list_published_notes(site) == [published]
+  end
+
+  test "paginates published notes separately from articles", %{site: site} do
+    notes =
+      Enum.map(1..21, fn index ->
+        post_fixture(%{
+          site: site,
+          kind: :note,
+          body: "Note #{index}",
+          status: :published,
+          published_at: DateTime.add(~U[2026-01-01 00:00:00Z], index, :day)
+        })
+      end)
+
+    {first_page, first_meta} = Publishing.paginate_published_notes(site, 1)
+    {second_page, second_meta} = Publishing.paginate_published_notes(site, 2)
+
+    assert Enum.map(first_page, & &1.id) ==
+             notes |> Enum.reverse() |> Enum.take(20) |> Enum.map(& &1.id)
+
+    assert Enum.map(second_page, & &1.id) == [hd(notes).id]
+    assert first_meta.has_next_page?
+    assert second_meta.has_previous_page?
+  end
+
   test "rejects invalid content", %{site: site} do
     assert {:error, %Ecto.Changeset{}} = Publishing.create_post(site, %{title: nil, body: nil})
   end

--- a/test/gesttalt/themes/renderer_test.exs
+++ b/test/gesttalt/themes/renderer_test.exs
@@ -23,14 +23,13 @@ defmodule Gesttalt.Themes.RendererTest do
 
     {:ok, theme} =
       Sites.update_theme(site, %{
-        article_template:
-          "<title>{{ post.title }}</title><main>{{ post.body_html }}</main><small>{{ post.reading_time }}</small>"
+        article_template: "<title>{{ post.title }}</title><main>{{ post.body_html }}</main>"
       })
 
     assert {:ok, html} = Renderer.render_article(site, theme, post, [])
     assert html =~ "<title>Safe themes</title>"
     assert html =~ "<h2>A heading</h2>"
-    assert html =~ "<small>1</small>"
+    refute html =~ "min read"
     refute html =~ "<script>"
   end
 

--- a/test/gesttalt_web/controllers/admin_controller_test.exs
+++ b/test/gesttalt_web/controllers/admin_controller_test.exs
@@ -24,6 +24,39 @@ defmodule GesttaltWeb.AdminControllerTest do
     assert response =~ ~s(datetime="2017-12-25T12:00:00Z")
   end
 
+  test "uses the active development port for public content links", %{conn: conn, user: user} do
+    {:ok, site} = Sites.ensure_site_for_user(user)
+    domain = Enum.find(site.domains, &(&1.status == :active))
+
+    post =
+      post_fixture(%{
+        site: site,
+        status: :published,
+        title: "A visible post",
+        slug: "a-visible-post"
+      })
+
+    response =
+      conn
+      |> Map.put(:host, "sc-flux-boson-0165.localhost")
+      |> Map.put(:port, 4817)
+      |> get(~p"/admin/")
+      |> html_response(200)
+
+    assert response =~ "http://#{domain.hostname}:4817/blog/#{post.slug}/"
+  end
+
+  test "provides a titleless short note editor", %{conn: conn} do
+    response = conn |> get(~p"/admin/notes/new") |> html_response(200)
+
+    assert response =~ "New note"
+    assert response =~ "Write up to 500 characters"
+    assert response =~ ~s(name="post[body]")
+    assert response =~ ~s(maxlength="500")
+    assert response =~ ~s(name="post[kind]" value="note")
+    refute response =~ ~s(name="post[title]")
+  end
+
   test "shows cookie-free page-view counts", %{conn: conn, user: user} do
     {:ok, site} = Sites.ensure_site_for_user(user)
     {:ok, _page_view} = Gesttalt.Analytics.record_page_view(site, %{path: "/", country: "ES"})

--- a/test/gesttalt_web/controllers/feed_controller_test.exs
+++ b/test/gesttalt_web/controllers/feed_controller_test.exs
@@ -115,6 +115,33 @@ defmodule GesttaltWeb.FeedControllerTest do
     assert body =~ ~s(href="/blog/atom.xml")
   end
 
+  test "serves Really Simple Syndication and Atom feeds for short notes", %{
+    conn: conn,
+    host: host,
+    site: site
+  } do
+    note =
+      post_fixture(%{
+        site: site,
+        kind: :note,
+        title: "Note",
+        body: "A **short** update.",
+        status: :published,
+        published_at: ~U[2026-07-21 12:00:00Z]
+      })
+
+    rss = conn |> Map.put(:host, host) |> get("/notes/feed.xml") |> response(200)
+
+    assert rss =~ "Notes from #{site.name}"
+    assert rss =~ "http://#{host}/notes/#{note.id}/"
+    assert rss =~ "<strong>short</strong>"
+
+    atom = build_conn() |> Map.put(:host, host) |> get("/notes/atom.xml") |> response(200)
+
+    assert atom =~ ~s(<link href="http://#{host}/notes/atom.xml" rel="self")
+    assert atom =~ "http://#{host}/notes/#{note.id}/"
+  end
+
   defp before?(body, first, second) do
     {first_position, _length} = :binary.match(body, first)
     {second_position, _length} = :binary.match(body, second)

--- a/test/gesttalt_web/controllers/publishing_interfaces_test.exs
+++ b/test/gesttalt_web/controllers/publishing_interfaces_test.exs
@@ -145,11 +145,7 @@ defmodule GesttaltWeb.PublishingInterfacesTest do
     assert [%{"title" => "From anywhere"}] = response
   end
 
-  test "keeps programmatic text publishing free", %{
-    conn: conn,
-    site: site,
-    token: token
-  } do
+  test "keeps programmatic text publishing free", %{conn: conn, token: token} do
     read_response =
       conn
       |> put_req_header("authorization", "Bearer #{token}")
@@ -167,6 +163,22 @@ defmodule GesttaltWeb.PublishingInterfacesTest do
       |> json_response(201)
 
     assert write_response["title"] == "Free draft"
+  end
+
+  test "creates titleless short notes through the application interface", %{
+    conn: conn,
+    token: token
+  } do
+    response =
+      conn
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> put_req_header("content-type", "application/json")
+      |> post(~p"/api/posts", JSON.encode!(%{body: "An application note.", kind: "note"}))
+      |> json_response(201)
+
+    assert response["kind"] == "note"
+    assert response["title"] == "Note"
+    assert response["url"] == nil
   end
 
   test "uploads and manages photography feed entries through the application interface", %{
@@ -258,6 +270,11 @@ defmodule GesttaltWeb.PublishingInterfacesTest do
     assert "delete_connected_application" in names
     refute "publish_theme" in names
 
+    content_tool = Enum.find(response["result"]["tools"], &(&1["name"] == "create_content"))
+
+    assert "note" in content_tool["inputSchema"]["properties"]["kind"]["enum"]
+    assert content_tool["inputSchema"]["required"] == ["body"]
+
     update_tool =
       Enum.find(response["result"]["tools"], &(&1["name"] == "update_theme_editing_session"))
 
@@ -298,6 +315,12 @@ defmodule GesttaltWeb.PublishingInterfacesTest do
 
     assert created["tags"] == ["agents", "publishing"]
     assert created["status"] == "published"
+
+    note =
+      call_tool(conn, token, 4, "create_content", %{body: "A tool-created note.", kind: "note"})
+
+    assert note["kind"] == "note"
+    assert note["title"] == "Note"
 
     unpublished = call_tool(conn, token, 4, "unpublish_content", %{id: created["id"]})
     assert unpublished["status"] == "draft"

--- a/test/gesttalt_web/controllers/site_controller_test.exs
+++ b/test/gesttalt_web/controllers/site_controller_test.exs
@@ -160,6 +160,11 @@ defmodule GesttaltWeb.SiteControllerTest do
         })
       )
 
+    {:ok, note} =
+      Gesttalt.Publishing.publish_post(
+        PublishingFixtures.post_fixture(%{site: site, kind: :note, body: "A linked note"})
+      )
+
     article = conn |> Map.put(:host, host) |> get("/blog/#{post.slug}.md")
     assert response(article, 200) =~ "# A linked post"
     assert get_resp_header(article, "content-type") == ["text/markdown; charset=utf-8"]
@@ -167,6 +172,7 @@ defmodule GesttaltWeb.SiteControllerTest do
     index = conn |> recycle() |> Map.put(:host, host) |> get("/llms.txt")
     assert response(index, 200) =~ "[A linked page](/#{page.slug}.md)"
     assert response(index, 200) =~ "[A linked post](/blog/#{post.slug}.md)"
+    assert response(index, 200) =~ "/notes/#{note.id}"
     assert get_resp_header(index, "content-type") == ["text/markdown; charset=utf-8"]
   end
 
@@ -242,6 +248,37 @@ defmodule GesttaltWeb.SiteControllerTest do
     assert second_page =~ "Page 2 of 2"
   end
 
+  test "renders a paginated notes archive", %{conn: conn, host: host, site: site} do
+    Enum.each(1..21, fn index ->
+      PublishingFixtures.post_fixture(%{
+        site: site,
+        kind: :note,
+        body: "Short update #{index}",
+        status: :published,
+        published_at: DateTime.add(~U[2026-01-01 00:00:00Z], index, :day)
+      })
+    end)
+
+    first_page = conn |> Map.put(:host, host) |> get(~p"/notes") |> html_response(200)
+
+    assert first_page =~ ~s(id="site-notes")
+    assert first_page =~ "Short update 21"
+    refute first_page =~ ">Short update 1</a>"
+    assert first_page =~ ~s(href="/notes?page=2")
+    assert first_page =~ ~s(href="/notes/feed.xml")
+    assert first_page =~ ~s(href="/notes/atom.xml")
+
+    second_page =
+      conn
+      |> recycle()
+      |> Map.put(:host, host)
+      |> get(~p"/notes?page=2")
+      |> html_response(200)
+
+    assert second_page =~ "Short update 1"
+    refute second_page =~ ">Short update 2</a>"
+  end
+
   test "redirects an archive page beyond the end to the last page", %{
     conn: conn,
     host: host,
@@ -291,5 +328,20 @@ defmodule GesttaltWeb.SiteControllerTest do
 
       assert length(Regex.scan(~r/<meta property="og:image"/, body)) == 1
     end
+  end
+
+  test "renders a published note at its individual route", %{conn: conn, host: host, site: site} do
+    note =
+      PublishingFixtures.post_fixture(%{
+        site: site,
+        kind: :note,
+        title: "Note",
+        body: "A short public update.",
+        status: :published
+      })
+
+    body = conn |> Map.put(:host, host) |> get("/notes/#{note.id}") |> html_response(200)
+
+    assert body =~ "A short public update."
   end
 end


### PR DESCRIPTION
## What changed

- Added short notes as a publication type, with a 500-character limit and titleless authoring.
- Added public note archives, individual note routes, pagination, feeds, theme navigation, and development seed data.
- Made notes available through the dashboard, programmatic publishing endpoint, and [Model Context Protocol](https://modelcontextprotocol.io/) tools.
- Corrected public dashboard links for development ports and ensured front-end dependencies are installed during asset setup.
- Removed estimated reading-time labels and refined the notes archive styling.

## Why

Publishers need a lightweight format for timely updates that should not be presented as long-form articles.

## Approach

Notes reuse the existing publication record with a dedicated kind. This preserves the existing publishing workflow while giving notes their own routes, archives, feeds, and presentation.

## Impact

Sites can publish short notes from every supported authoring surface. Visitors can browse them at `/notes`, open individual notes, and subscribe to the separate feeds.

## Validation

- `mix assets.build`
- `mix test test/gesttalt/themes/renderer_test.exs test/gesttalt/open_graph/card_test.exs test/gesttalt/open_graph_test.exs test/gesttalt_web/controllers/site_controller_test.exs`
- `mix test test/gesttalt/themes/renderer_test.exs`
- `git diff --check`
- Captured the notes archive in headless Chrome after the final styling changes.
