### PR TITLE
fix(gesttalt): preserve Caddy authorization route order

### DIFF
--- a/deploy/helm/gesttalt/templates/caddy-config.yaml
+++ b/deploy/helm/gesttalt/templates/caddy-config.yaml
@@ -22,14 +22,16 @@ data:
     }
 
     http://:{{ .Values.caddy.httpPort }} {
-      @domain_allow path /internal/domains/allow
-      handle @domain_allow {
-        reverse_proxy {{ include "gesttalt.fullname" . }}-web:4000 {
-          header_up X-Forwarded-For {client_ip}
-          header_up X-Forwarded-Proto https
+      route {
+        @domain_allow path /internal/domains/allow
+        handle @domain_allow {
+          reverse_proxy {{ include "gesttalt.fullname" . }}-web:4000 {
+            header_up X-Forwarded-For {client_ip}
+            header_up X-Forwarded-Proto https
+          }
         }
+        redir https://{host}{uri} permanent
       }
-      redir https://{host}{uri} permanent
     }
 
     https://:{{ .Values.caddy.httpsPort }} {


### PR DESCRIPTION
## What changed

- Wrapped Caddy's internal certificate authorization handler and the HTTP redirect in an explicit ordered route.

## Root cause

Caddy orders directives automatically. It placed the HTTP redirect before the authorization handler, so the internal authorization request was still redirected to public HTTPS and certificate issuance failed.

## Approach

The ordered route evaluates the authorization handler first and redirects every other HTTP request afterward.

## Impact

Gesttalt can complete on-demand certificate authorization after the proxy and application deployments are separated.

## Validation

- `helm lint deploy/helm/gesttalt --values deploy/values-production.yaml`
- Rendered the production chart.
- Adapted the rendered Caddyfile with the live Caddy binary and asserted the authorization handler precedes the redirect.
