### PR TITLE
fix(gesttalt): preserve admin destination after email login

### DIFF
--- a/lib/gesttalt_web/controllers/user_session_controller.ex
+++ b/lib/gesttalt_web/controllers/user_session_controller.ex
@@ -72,9 +72,15 @@ defmodule GesttaltWeb.UserSessionController do
   # magic link request
   def create(conn, %{"user" => %{"email" => email}}) do
     if user = Accounts.get_user_by_email(email) do
+      login_url =
+        case UserAuth.sign_login_return_to(conn, user) do
+          nil -> &url(~p"/users/log-in/#{&1}")
+          return_to -> &url(~p"/users/log-in/#{&1}?return_to=#{return_to}")
+        end
+
       Accounts.deliver_login_instructions(
         user,
-        &url(~p"/users/log-in/#{&1}")
+        login_url
       )
     end
 
@@ -86,11 +92,12 @@ defmodule GesttaltWeb.UserSessionController do
     |> redirect(to: ~p"/users/log-in")
   end
 
-  def confirm(conn, %{"token" => token}) do
+  def confirm(conn, %{"token" => token} = params) do
     if user = Accounts.get_user_by_magic_link_token(token) do
       form = Phoenix.Component.to_form(%{"token" => token}, as: "user")
 
       conn
+      |> UserAuth.restore_login_return_to(user, params["return_to"])
       |> assign(:user, user)
       |> assign(:form, form)
       |> render(:confirm)

--- a/lib/gesttalt_web/user_auth.ex
+++ b/lib/gesttalt_web/user_auth.ex
@@ -14,6 +14,8 @@ defmodule GesttaltWeb.UserAuth do
   @max_cookie_age_in_days 14
   @remember_me_cookie "_gesttalt_web_user_remember_me"
   @secure_cookies Application.compile_env(:gesttalt, :secure_cookies, false)
+  @login_return_to_salt "login return to"
+  @login_return_to_max_age_in_seconds 15 * 60
   @remember_me_options [
     sign: true,
     max_age: @max_cookie_age_in_days * 24 * 60 * 60,
@@ -44,6 +46,32 @@ defmodule GesttaltWeb.UserAuth do
     |> create_or_extend_session(user, params)
     |> redirect(to: user_return_to || signed_in_path(conn))
   end
+
+  @doc false
+  def sign_login_return_to(conn, user) do
+    case get_session(conn, :user_return_to) do
+      return_to when is_binary(return_to) ->
+        Phoenix.Token.sign(conn, @login_return_to_salt, {user.id, return_to})
+
+      _return_to ->
+        nil
+    end
+  end
+
+  @doc false
+  def restore_login_return_to(conn, user, token) when is_binary(token) do
+    case Phoenix.Token.verify(conn, @login_return_to_salt, token,
+           max_age: @login_return_to_max_age_in_seconds
+         ) do
+      {:ok, {user_id, return_to}} when user_id == user.id and is_binary(return_to) ->
+        put_session(conn, :user_return_to, return_to)
+
+      _result ->
+        conn
+    end
+  end
+
+  def restore_login_return_to(conn, _user, _token), do: conn
 
   @doc """
   Logs the user out.

--- a/priv/changelog/2026-08-11-email-login-return.md
+++ b/priv/changelog/2026-08-11-email-login-return.md
@@ -1,0 +1,7 @@
+%{
+  title: "Return to your publication after email sign-in",
+  summary: "Email sign-in now resumes the dashboard domain and page that requested authentication."
+}
+---
+
+Opening a sign-in email now returns you to the publication dashboard that asked you to log in. The requested dashboard page travels with the email as a signed, short-lived continuation, so opening the message in a new tab no longer falls back to the central Gesttalt dashboard.

--- a/test/gesttalt_web/controllers/user_session_controller_test.exs
+++ b/test/gesttalt_web/controllers/user_session_controller_test.exs
@@ -3,6 +3,7 @@ defmodule GesttaltWeb.UserSessionControllerTest do
 
   import Gesttalt.AccountsFixtures
   alias Gesttalt.Accounts
+  alias GesttaltWeb.UserAuth
 
   setup do
     %{unconfirmed_user: unconfirmed_user_fixture(), user: user_fixture()}
@@ -75,6 +76,29 @@ defmodule GesttaltWeb.UserSessionControllerTest do
 
       assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
                "Magic link is invalid or has expired. Request a new link below."
+    end
+
+    test "ignores a protected destination signed for another account", %{
+      conn: conn,
+      user: user
+    } do
+      other_user = user_fixture()
+      {token, _hashed_token} = generate_user_magic_link_token(user)
+
+      signed_return_to =
+        conn
+        |> init_test_session(user_return_to: "/admin/session/start?host=writing.example")
+        |> put_private(:phoenix_endpoint, GesttaltWeb.Endpoint)
+        |> UserAuth.sign_login_return_to(other_user)
+
+      conn =
+        conn
+        |> recycle()
+        |> init_test_session(%{})
+        |> get(~p"/users/log-in/#{token}?return_to=#{signed_return_to}")
+
+      assert html_response(conn, 200) =~ "Log in"
+      refute get_session(conn, :user_return_to)
     end
   end
 
@@ -152,6 +176,40 @@ defmodule GesttaltWeb.UserSessionControllerTest do
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "If your email is in our system"
       assert Gesttalt.Repo.get_by!(Accounts.UserToken, user_id: user.id).context == "login"
+    end
+
+    test "restores the protected destination from the magic link", %{conn: conn, user: user} do
+      return_to =
+        "/admin/session/start?host=writing.example&state=state&return_to=%2Fadmin%2Fanalytics"
+
+      assert_receive {:email, _fixture_email}
+
+      conn
+      |> init_test_session(user_return_to: return_to)
+      |> post(~p"/users/log-in", %{"user" => %{"email" => user.email}})
+
+      assert_receive {:email, email}
+      assert email.to == [{"", user.email}]
+      assert email.subject == "Your gesttalt login link"
+      assert [link] = Regex.run(~r/Log in: (\S+)/, email.text_body, capture: :all_but_first)
+
+      uri = URI.parse(link)
+      token = uri.path |> String.split("/") |> List.last()
+
+      fresh_conn =
+        conn
+        |> recycle()
+        |> init_test_session(%{})
+        |> get(uri.path <> "?" <> uri.query)
+
+      assert get_session(fresh_conn, :user_return_to) == return_to
+
+      logged_in_conn =
+        fresh_conn
+        |> recycle()
+        |> post(~p"/users/log-in", %{"user" => %{"token" => token}})
+
+      assert redirected_to(logged_in_conn) == return_to
     end
 
     test "logs the user in", %{conn: conn, user: user} do


### PR DESCRIPTION
## What changed

Email sign-in links now carry the protected destination that initiated authentication. The destination is restored when the link is opened, and regression coverage verifies both successful restoration and rejection when the continuation belongs to another account.

The public changelog now documents that email sign-in resumes the original publication dashboard page.

## Why

Opening a publication dashboard should return the publisher to that same publication after authentication. This is especially important for dashboards served from custom publication domains.

## Root cause

The destination was stored only in the central-domain browser session. The email contained the account sign-in token but not the destination, so opening it without that exact session fell back to the central Gesttalt dashboard.

## Approach

The email link includes a signed continuation bound to the account and limited to fifteen minutes, matching the sign-in link lifetime. The confirmation request verifies the continuation before restoring it to the browser session. Missing, invalid, expired, or wrong-account continuations are ignored.

## Impact

Publishers now return to the requested publication domain and dashboard page after email sign-in. Existing links without a continuation retain their previous fallback behavior. No database migration or manual action is required.

## Validation

- `MIX_ENV=test mix format --check-formatted`
- `mix credo --strict`, with no issues
- `mix test`, with 305 tests passing
- Headless Chrome completed the central sign-in and publication handoff, returning to `writing.localhost/admin/analytics?period=7`

## Screenshots

| Before | After |
| --- | --- |
| ![Central sign-in before email continuation](https://github.com/pepicrft/gesttalt/blob/60499afe14006854ab5553aa645a332ef628b1ab/before-email-login.png?raw=true) | ![Publication analytics after email continuation](https://github.com/pepicrft/gesttalt/blob/60499afe14006854ab5553aa645a332ef628b1ab/after-email-login.png?raw=true) |
