### PR TITLE
fix(gesttalt): render note Markdown and social images

### DIFF
--- a/lib/gesttalt/markdown.ex
+++ b/lib/gesttalt/markdown.ex
@@ -9,4 +9,18 @@ defmodule Gesttalt.Markdown do
   end
 
   def to_html(nil), do: Phoenix.HTML.raw("")
+
+  @doc "Turns Markdown into compact plain text for contexts that cannot render HTML."
+  def to_text(markdown) when is_binary(markdown) do
+    markdown
+    |> MDEx.to_delta!()
+    |> Enum.map_join(fn
+      %{"insert" => insert} when is_binary(insert) -> insert
+      _operation -> ""
+    end)
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+  end
+
+  def to_text(nil), do: ""
 end

--- a/lib/gesttalt/open_graph.ex
+++ b/lib/gesttalt/open_graph.ex
@@ -14,6 +14,7 @@ defmodule Gesttalt.OpenGraph do
   Gesttalt itself produced.
   """
 
+  alias Gesttalt.Markdown
   alias Gesttalt.MediaStorage
   alias Gesttalt.OpenGraph.{Card, Signer}
   alias Gesttalt.Publishing
@@ -25,7 +26,7 @@ defmodule Gesttalt.OpenGraph do
   @content_type "image/jpeg"
 
   @typedoc "A page whose Open Graph image can be rendered."
-  @type subject :: {:post, Post.t()} | {:page, Post.t()} | {:home, Site.t()}
+  @type subject :: {:post, Post.t()} | {:page, Post.t()} | {:note, Post.t()} | {:home, Site.t()}
 
   @typedoc "Context needed to mint an absolute, signed image URL."
   @type url_context :: %{site: Site.t(), theme: term(), base_url: String.t()}
@@ -37,8 +38,9 @@ defmodule Gesttalt.OpenGraph do
   def image_url({:home, %Site{} = site}, %{base_url: base_url} = ctx),
     do: build_url(base_url, home_params(site, ctx))
 
-  def image_url({kind, %Post{} = post}, %{base_url: base_url} = ctx) when kind in [:post, :page],
-    do: build_url(base_url, post_params(kind, post, ctx))
+  def image_url({kind, %Post{} = post}, %{base_url: base_url} = ctx)
+      when kind in [:post, :page, :note],
+      do: build_url(base_url, post_params(kind, post, ctx))
 
   defp build_url(base_url, params) do
     params = Map.put(params, "sig", Signer.sign(params, secret()))
@@ -123,7 +125,7 @@ defmodule Gesttalt.OpenGraph do
 
     case MediaStorage.get(key) do
       {:ok, bytes} -> {:ok, bytes}
-      {:error, :not_found} -> render_locked(key, html)
+      {:error, reason} when reason in [:not_found, :enoent] -> render_locked(key, html)
       {:error, _reason} = error -> error
     end
   end
@@ -137,7 +139,7 @@ defmodule Gesttalt.OpenGraph do
       # Another request may have rendered while we waited for the lock.
       case MediaStorage.get(key) do
         {:ok, bytes} -> {:ok, bytes}
-        {:error, :not_found} -> render_and_store(key, html)
+        {:error, reason} when reason in [:not_found, :enoent] -> render_and_store(key, html)
         {:error, _reason} = error -> error
       end
     end)
@@ -161,7 +163,8 @@ defmodule Gesttalt.OpenGraph do
 
   defp subject(%Site{} = site, %{"kind" => "home"}), do: {:ok, {:home, site}}
 
-  defp subject(%Site{} = site, %{"kind" => kind, "id" => id}) when kind in ["post", "page"] do
+  defp subject(%Site{} = site, %{"kind" => kind, "id" => id})
+       when kind in ["post", "page", "note"] do
     kind_atom = String.to_existing_atom(kind)
 
     case Publishing.get_published_post(site, kind_atom, id) do
@@ -179,6 +182,16 @@ defmodule Gesttalt.OpenGraph do
       title: site.tagline || site.name,
       subtitle: if(site.tagline, do: site.name, else: ""),
       meta: ""
+    }
+  end
+
+  defp card_assigns({:note, %Post{} = post}, %Site{} = site) do
+    %{
+      variables: theme_variables(site),
+      eyebrow: site.name,
+      title: Markdown.to_text(post.body),
+      subtitle: "",
+      meta: post_meta(:note, post)
     }
   end
 
@@ -207,6 +220,8 @@ defmodule Gesttalt.OpenGraph do
       published_at -> Calendar.strftime(published_at, "%B %-d, %Y")
     end
   end
+
+  defp post_meta(:note, %Post{} = post), do: post_meta(:post, post)
 
   defp theme_variables(%Site{theme: %{variables: variables}}), do: variables
   defp theme_variables(_site), do: nil

--- a/lib/gesttalt/themes/renderer.ex
+++ b/lib/gesttalt/themes/renderer.ex
@@ -209,8 +209,7 @@ defmodule Gesttalt.Themes.Renderer do
   defp post_og_image(_post, nil), do: ""
 
   defp post_og_image(post, og) do
-    kind = if post.kind == :page, do: :page, else: :post
-    OpenGraph.image_url({kind, post}, og)
+    OpenGraph.image_url({post.kind, post}, og)
   end
 
   defp post_context(post, og \\ nil) do

--- a/priv/changelog/2026-08-11-note-markdown-and-social-images.md
+++ b/priv/changelog/2026-08-11-note-markdown-and-social-images.md
@@ -1,0 +1,9 @@
+%{
+  title: "Render Markdown and social images for notes",
+  summary: "Show formatted note content and reliable social previews."
+}
+---
+
+Notes now render Markdown in the notes archive, so links, emphasis, and other formatting appear as intended without hiding a note's permanent address.
+
+Each note also has a working social preview image that uses its content and the publication's selected theme.

--- a/priv/themes/paper/index.liquid
+++ b/priv/themes/paper/index.liquid
@@ -35,10 +35,10 @@
       <p class="section-label">{% if is_notes %}Notes{% elsif is_archive %}Writing{% else %}Recent writing{% endif %}</p>
       <section class="posts-list">
         {% for post in posts %}
-        <article class="post-row">
-          <time datetime="{{ post.published_at }}">{{ post.published_on }}</time>
+        <article id="{% if is_notes %}note{% else %}post{% endif %}-{{ post.id }}" class="post-row">
+          {% if is_notes %}<a data-part="permalink" href="{{ post.url }}"><time datetime="{{ post.published_at }}">{{ post.published_on }}</time></a>{% else %}<time datetime="{{ post.published_at }}">{{ post.published_on }}</time>{% endif %}
           <div class="post-copy">
-            {% if is_notes %}<a class="note-link" href="{{ post.url }}">{{ post.body }}</a>{% else %}<a class="post-link" href="{{ post.url }}">{{ post.title }}</a><p>{{ post.excerpt }}</p>{% endif %}
+            {% if is_notes %}<div class="prose" data-part="body">{{ post.body_html }}</div>{% else %}<a class="post-link" href="{{ post.url }}">{{ post.title }}</a><p>{{ post.excerpt }}</p>{% endif %}
           </div>
         </article>
         {% endfor %}

--- a/priv/themes/paper/theme.css
+++ b/priv/themes/paper/theme.css
@@ -8,7 +8,6 @@ a:hover { color: var(--gesttalt-colors-primary); }
 .header-inner { align-items: flex-start; display: flex; flex-direction: column; gap: 1.5rem; }
 .site-identity { display: flex; flex-direction: column; }
 .site-title, nav a, .post-link { font-weight: var(--gesttalt-font-weights-bold); text-decoration: none; }
-.note-link { font-weight: var(--gesttalt-font-weights-body); text-decoration: none; }
 .site-tagline, time, .post-copy p, #site-footer { color: var(--gesttalt-colors-muted-text); }
 nav { display: flex; flex-wrap: wrap; gap: 1rem; }
 .page { padding-block: 2.5rem; }
@@ -50,6 +49,19 @@ h1 { font-family: var(--gesttalt-fonts-heading); font-size: var(--gesttalt-font-
     & > [data-part="previous"] { grid-column: 1; justify-self: start; }
     & > [data-part="status"] { grid-column: 2; color: var(--gesttalt-colors-muted-text); }
     & > [data-part="next"] { grid-column: 3; justify-self: end; }
+  }
+}
+#site-notes {
+  & [data-part="permalink"] {
+    color: var(--gesttalt-colors-muted-text);
+    text-decoration: none;
+  }
+
+  & [data-part="body"] {
+    color: var(--gesttalt-colors-text);
+
+    & > :first-child { margin-top: 0; }
+    & > :last-child { margin-bottom: 0; }
   }
 }
 #site-footer {

--- a/test/gesttalt/markdown_test.exs
+++ b/test/gesttalt/markdown_test.exs
@@ -1,0 +1,13 @@
+defmodule Gesttalt.MarkdownTest do
+  use ExUnit.Case, async: true
+
+  alias Gesttalt.Markdown
+
+  test "turns Markdown into compact plain text" do
+    markdown =
+      "## A heading\n\nBullish on [Once](https://buildonce.dev) and **agent-friendly builds**."
+
+    assert Markdown.to_text(markdown) ==
+             "A heading Bullish on Once and agent-friendly builds."
+  end
+end

--- a/test/gesttalt/open_graph_test.exs
+++ b/test/gesttalt/open_graph_test.exs
@@ -30,6 +30,17 @@ defmodule Gesttalt.OpenGraphTest do
       assert {:ok, "JPEG:" <> _} = OpenGraph.render(site, %{"kind" => "post", "id" => post.id})
     end
 
+    test "renders when local storage reports a missing file", %{site: site} do
+      post = published_post(site)
+
+      stub(MediaStorage, :get, fn _key -> {:error, :enoent} end)
+      expect(Carta, :render, fn _pool, html, _opts -> {:ok, "LOCAL-JPEG:" <> html} end)
+      expect(MediaStorage, :put, fn _key, "LOCAL-JPEG:" <> _rest, "image/jpeg" -> :ok end)
+
+      assert {:ok, "LOCAL-JPEG:" <> _} =
+               OpenGraph.render(site, %{"kind" => "post", "id" => post.id})
+    end
+
     test "serves from storage without rendering on a cache hit", %{site: site} do
       post = published_post(site)
 
@@ -45,6 +56,24 @@ defmodule Gesttalt.OpenGraphTest do
       stub(MediaStorage, :put, fn _key, _body, _content_type -> :ok end)
 
       assert {:ok, "HOME-JPEG"} = OpenGraph.render(site, %{"kind" => "home"})
+    end
+
+    test "renders a published note", %{site: site} do
+      note =
+        published_post(site, %{
+          kind: :note,
+          body: "A short update about [Once](https://buildonce.dev)."
+        })
+
+      stub(MediaStorage, :get, fn _key -> {:error, :not_found} end)
+      expect(Carta, :render, fn _pool, html, _opts -> {:ok, "NOTE-JPEG:" <> html} end)
+      stub(MediaStorage, :put, fn _key, _body, _content_type -> :ok end)
+
+      assert {:ok, "NOTE-JPEG:" <> html} =
+               OpenGraph.render(site, %{"kind" => "note", "id" => note.id})
+
+      assert html =~ "A short update about Once."
+      refute html =~ "[Once](https://buildonce.dev)"
     end
 
     test "returns :not_found for an unpublished post without rendering", %{site: site} do
@@ -79,6 +108,21 @@ defmodule Gesttalt.OpenGraphTest do
       assert String.starts_with?(url, "https://example.test/og-image?")
 
       params = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+      assert OpenGraph.verify_signature(params)
+    end
+
+    test "mints a signed note URL with the note kind", %{site: site} do
+      note = published_post(site, %{kind: :note, body: "A short public update."})
+      ctx = %{site: site, theme: site.theme, base_url: "https://example.test"}
+
+      params =
+        {:note, note}
+        |> OpenGraph.image_url(ctx)
+        |> URI.parse()
+        |> Map.fetch!(:query)
+        |> URI.decode_query()
+
+      assert params["kind"] == "note"
       assert OpenGraph.verify_signature(params)
     end
 

--- a/test/gesttalt_web/controllers/open_graph_controller_test.exs
+++ b/test/gesttalt_web/controllers/open_graph_controller_test.exs
@@ -83,4 +83,21 @@ defmodule GesttaltWeb.OpenGraphControllerTest do
     assert get_resp_header(conn, "content-type") == ["image/jpeg"]
     assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
   end
+
+  test "serves a signed, published note image", %{conn: conn, host: host, site: site} do
+    {:ok, note} =
+      Gesttalt.Publishing.publish_post(
+        post_fixture(%{site: site, kind: :note, body: "A short public update."})
+      )
+
+    params = %{"kind" => "note", "id" => note.id, "site" => site.id, "v" => "0-0"}
+
+    stub(MediaStorage, :get, fn _key -> {:ok, "STORED-NOTE-JPEG"} end)
+    reject(&Carta.render/3)
+
+    conn = conn |> Map.put(:host, host) |> get("/og-image?" <> signed_query(params))
+
+    assert "STORED-NOTE-JPEG" = response(conn, 200)
+    assert get_resp_header(conn, "content-type") == ["image/jpeg"]
+  end
 end

--- a/test/gesttalt_web/controllers/site_controller_test.exs
+++ b/test/gesttalt_web/controllers/site_controller_test.exs
@@ -283,6 +283,24 @@ defmodule GesttaltWeb.SiteControllerTest do
     refute second_page =~ ">Short update 2</a>"
   end
 
+  test "renders Markdown in the notes archive", %{conn: conn, host: host, site: site} do
+    note =
+      PublishingFixtures.post_fixture(%{
+        site: site,
+        kind: :note,
+        body: "Bullish on [Once](https://buildonce.dev) and **agent-friendly builds**.",
+        status: :published
+      })
+
+    body = conn |> Map.put(:host, host) |> get(~p"/notes") |> html_response(200)
+
+    assert body =~ ~s(href="https://buildonce.dev")
+    assert body =~ ">Once</a>"
+    assert body =~ "<strong>agent-friendly builds</strong>"
+    assert body =~ ~s(href="/notes/#{note.id}/")
+    refute body =~ "[Once](https://buildonce.dev)"
+  end
+
   test "redirects an archive page beyond the end to the last page", %{
     conn: conn,
     host: host,
@@ -310,10 +328,16 @@ defmodule GesttaltWeb.SiteControllerTest do
         PublishingFixtures.post_fixture(%{site: site, kind: :page, slug: "about", title: "About"})
       )
 
+    {:ok, note} =
+      Gesttalt.Publishing.publish_post(
+        PublishingFixtures.post_fixture(%{site: site, kind: :note, body: "A short note"})
+      )
+
     for {path, type, title} <- [
           {"/", "website", site.name},
           {"/blog", "website", "Writing · #{site.name}"},
           {"/blog/#{post.slug}", "article", post.title},
+          {"/notes/#{note.id}", "article", note.title},
           {"/#{page.slug}", "website", page.title},
           {"/photography", "website", "Photography · #{site.name}"}
         ] do
@@ -331,6 +355,10 @@ defmodule GesttaltWeb.SiteControllerTest do
                ~r/<meta name="twitter:image" content="https?:\/\/#{Regex.escape(host)}\/og-image\?/
 
       assert length(Regex.scan(~r/<meta property="og:image"/, body)) == 1
+
+      if path == "/notes/#{note.id}" do
+        assert body =~ "kind=note"
+      end
     end
   end
 


### PR DESCRIPTION
## What changed

The notes archive now renders each note through the existing sanitized Markdown path. The publication date remains a permanent link to the individual note, while links and emphasis inside the note retain their intended behavior.

Note social previews now carry the note content kind through signed image addresses, subject lookup, rendering, and caching. Preview cards use compact plain text derived from Markdown, and a fresh local cache can render its first image correctly.

The public changelog documents both improvements.

## Why

Readers should see note formatting as the author intended, including functional links. Shared note addresses should also produce a useful social preview instead of a missing image response.

## Root cause

The built-in notes template displayed the raw note body and wrapped it in a permanent link. Separately, social image generation classified every non-page publication as a post, while the image endpoint only resolved records that matched the supplied content kind. Note identifiers therefore failed the post lookup.

Local image storage reports a missing file differently from object storage, and the first-render path did not recognize that result as an empty cache.

## Approach

The archive consumes the renderer's existing sanitized Markdown output and moves the permanent link to the publication date. Route-scoped styles preserve the notes layout and text color.

The social image pipeline now treats notes as first-class subjects. It signs note image addresses with the note kind, resolves published notes through the tenant boundary, converts Markdown to compact plain text for the card, and recognizes both supported missing-cache results before rendering.

## Impact

Published notes show working Markdown links and emphasis in the archive. Sharing an individual note now produces a theme-matched social image based on the note content. No database migration or manual action is required.

## Validation

- `mix precommit`, with no code-quality issues and 311 tests passing
- `git diff --check`
- Headless Chrome verified the notes archive and the rendered social image
- The signed note image endpoint returned a successful 1200 by 630 image response

## Screenshots

### Notes archive

| Before | After |
| --- | --- |
| ![Raw Markdown in the notes archive](https://raw.githubusercontent.com/pepicrft/gesttalt/pr-assets-notes-markdown-73b10f2/pr-assets/notes-markdown-before.png) | ![Rendered Markdown in the notes archive](https://raw.githubusercontent.com/pepicrft/gesttalt/pr-assets-notes-markdown-73b10f2/pr-assets/notes-markdown-after.png) |

### Social preview image

| Before | After |
| --- | --- |
| ![Missing note social preview](https://raw.githubusercontent.com/pepicrft/gesttalt/pr-assets-notes-markdown-73b10f2/pr-assets/note-social-image-before.png) | ![Rendered note social preview](https://raw.githubusercontent.com/pepicrft/gesttalt/pr-assets-notes-markdown-73b10f2/pr-assets/note-social-image-after.png) |
