### PR TITLE
feat(gesttalt): add Inquiry and Studio editorial themes

### DIFF
--- a/lib/gesttalt/media_storage/local.ex
+++ b/lib/gesttalt/media_storage/local.ex
@@ -11,7 +11,12 @@ defmodule Gesttalt.MediaStorage.Local do
   end
 
   @impl true
-  def get(storage_key, options), do: File.read(path(storage_key, options))
+  def get(storage_key, options) do
+    case File.read(path(storage_key, options)) do
+      {:error, :enoent} -> {:error, :not_found}
+      result -> result
+    end
+  end
 
   @impl true
   def delete(storage_key, options) do

--- a/lib/gesttalt/open_graph.ex
+++ b/lib/gesttalt/open_graph.ex
@@ -175,9 +175,11 @@ defmodule Gesttalt.OpenGraph do
   defp card_assigns({:home, %Site{} = site}, _site) do
     %{
       variables: theme_variables(site),
+      variant: theme_variant(site),
       eyebrow: site.name,
       title: site.tagline || site.name,
-      subtitle: if(site.tagline, do: site.name, else: ""),
+      subtitle:
+        if(site.tagline, do: "Writing, notes, and photographs from #{site.name}.", else: ""),
       meta: ""
     }
   end
@@ -185,6 +187,7 @@ defmodule Gesttalt.OpenGraph do
   defp card_assigns({kind, %Post{} = post}, %Site{} = site) do
     %{
       variables: theme_variables(site),
+      variant: theme_variant(site),
       eyebrow: site.name,
       title: post.title,
       subtitle: post.excerpt || "",
@@ -210,6 +213,12 @@ defmodule Gesttalt.OpenGraph do
 
   defp theme_variables(%Site{theme: %{variables: variables}}), do: variables
   defp theme_variables(_site), do: nil
+
+  defp theme_variant(%Site{theme: %{built_in_theme: variant}})
+       when variant in ["inquiry", "studio"],
+       do: variant
+
+  defp theme_variant(_site), do: "default"
 
   defp secret do
     :gesttalt

--- a/lib/gesttalt/open_graph/card.ex
+++ b/lib/gesttalt/open_graph/card.ex
@@ -96,8 +96,9 @@ defmodule Gesttalt.OpenGraph.Card do
       font-size: 74px;
       font-weight: 650;
       letter-spacing: -.06em;
-      line-height: .94;
+      line-height: 1.06;
       overflow: hidden;
+      padding-bottom: .08em;
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 3;
     }
@@ -157,8 +158,9 @@ defmodule Gesttalt.OpenGraph.Card do
       font-size: 72px;
       font-weight: 700;
       letter-spacing: -.055em;
-      line-height: .96;
+      line-height: 1.06;
       overflow: hidden;
+      padding-bottom: .08em;
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 3;
     }

--- a/lib/gesttalt/open_graph/card.ex
+++ b/lib/gesttalt/open_graph/card.ex
@@ -39,6 +39,7 @@ defmodule Gesttalt.OpenGraph.Card do
     subtitle = Map.get(assigns, :subtitle, "")
     meta = Map.get(assigns, :meta, "")
     theme_fingerprint = Map.get(assigns, :theme_fingerprint, "")
+    layout = layout(assigns)
 
     """
     <!doctype html>
@@ -50,78 +51,220 @@ defmodule Gesttalt.OpenGraph.Card do
           * { margin: 0; padding: 0; box-sizing: border-box; }
           html, body { width: #{@width}px; height: #{@height}px; }
           body {
-            display: flex;
-            flex-direction: column;
-            justify-content: space-between;
-            padding: 72px 80px;
             background: #{css(colors["background"])};
             color: #{css(colors["text"])};
             font-family: #{css(fonts["body"])};
-          }
-          .accent-bar {
-            width: 96px;
-            height: 10px;
-            border-radius: 9999px;
-            background: #{css(colors["primary"])};
-          }
-          .eyebrow {
-            font-size: 26px;
-            font-weight: 600;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-            color: #{css(colors["mutedText"])};
-          }
-          .title {
-            font-family: #{css(fonts["heading"])};
-            font-size: 78px;
-            line-height: 1.08;
-            font-weight: 700;
-            color: #{css(colors["text"])};
-            display: -webkit-box;
-            -webkit-line-clamp: 3;
-            -webkit-box-orient: vertical;
             overflow: hidden;
           }
-          .subtitle {
-            font-size: 34px;
-            line-height: 1.4;
-            color: #{css(colors["mutedText"])};
-            display: -webkit-box;
-            -webkit-line-clamp: 2;
-            -webkit-box-orient: vertical;
-            overflow: hidden;
-          }
-          .stack { display: flex; flex-direction: column; gap: 28px; }
-          .head { display: flex; flex-direction: column; gap: 24px; }
-          .foot {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            font-size: 26px;
-            color: #{css(colors["mutedText"])};
-            border-top: 2px solid #{css(colors["border"])};
-            padding-top: 28px;
-          }
-          .foot .meta { color: #{css(colors["accent"])}; font-weight: 600; }
+          #{layout_styles(layout, colors, fonts)}
         </style>
       </head>
-      <body>
-        <div class="head">
-          <div class="accent-bar"></div>
-          <div class="eyebrow">#{escape(eyebrow)}</div>
-        </div>
-        <div class="stack">
-          <div class="title">#{escape(title)}</div>
-          #{if subtitle == "", do: "", else: ~s(<div class="subtitle">#{escape(subtitle)}</div>)}
-        </div>
-        <div class="foot">
-          <span>#{escape(eyebrow)}</span>
-          <span class="meta">#{escape(meta)}</span>
-        </div>
+      <body data-layout="#{layout}">
+        #{layout_markup(layout, eyebrow, title, subtitle, meta)}
       </body>
     </html>
     """
   end
+
+  defp layout(%{variant: variant}) when variant in ["inquiry", "studio"], do: variant
+  defp layout(_assigns), do: "default"
+
+  defp layout_styles("studio", colors, fonts) do
+    """
+    body { display: grid; grid-template-rows: 86px 1fr 78px; }
+    .studio-top {
+      align-items: center;
+      border-bottom: 2px solid #{css(colors["border"])};
+      display: flex;
+      font-family: #{css(fonts["heading"])};
+      justify-content: space-between;
+      padding-inline: 58px;
+    }
+    .studio-wordmark { font-size: 28px; font-weight: 700; letter-spacing: -.04em; }
+    .studio-meta {
+      border: 2px solid #{css(colors["text"])};
+      border-radius: 9999px;
+      font-size: 19px;
+      padding: 10px 17px;
+    }
+    .studio-main { display: grid; grid-template-columns: minmax(0, 1.7fr) minmax(300px, .7fr); }
+    .studio-copy { display: flex; flex-direction: column; justify-content: center; padding: 44px 58px; }
+    .studio-title {
+      color: #{css(colors["text"])};
+      display: -webkit-box;
+      font-family: #{css(fonts["heading"])};
+      font-size: 74px;
+      font-weight: 650;
+      letter-spacing: -.06em;
+      line-height: .94;
+      overflow: hidden;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+    }
+    .studio-subtitle {
+      color: #{css(colors["mutedText"])};
+      display: -webkit-box;
+      font-size: 25px;
+      line-height: 1.28;
+      margin-top: 25px;
+      max-width: 620px;
+      overflow: hidden;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+    }
+    .studio-panels { display: grid; gap: 2px; grid-template-rows: repeat(3, 1fr); padding: 18px 18px 18px 0; }
+    .studio-panel:nth-child(1) { background: #dceaff; }
+    .studio-panel:nth-child(2) { background: #eee2ff; }
+    .studio-panel:nth-child(3) { background: #f5e3d5; }
+    .studio-foot {
+      align-items: center;
+      background: #{css(colors["text"])};
+      color: #{css(colors["background"])};
+      display: flex;
+      font-family: #{css(fonts["heading"])};
+      font-size: 20px;
+      justify-content: space-between;
+      padding-inline: 58px;
+    }
+    .studio-foot span:last-child { font-weight: 700; }
+    """
+  end
+
+  defp layout_styles("inquiry", colors, fonts) do
+    """
+    body { display: grid; grid-template-rows: 78px 1fr 72px; padding-inline: 62px; }
+    .inquiry-top {
+      align-items: center;
+      display: flex;
+      font-family: #{css(fonts["heading"])};
+      justify-content: space-between;
+    }
+    .inquiry-wordmark { font-size: 26px; font-weight: 700; letter-spacing: .035em; text-transform: uppercase; }
+    .inquiry-meta { color: #{css(colors["mutedText"])}; font-size: 19px; }
+    .inquiry-main {
+      align-items: center;
+      border-bottom: 2px solid #{css(colors["border"])};
+      border-top: 2px solid #{css(colors["border"])};
+      display: grid;
+      gap: 58px;
+      grid-template-columns: minmax(0, 1.08fr) minmax(0, .92fr);
+      padding-block: 38px;
+    }
+    .inquiry-title {
+      color: #{css(colors["text"])};
+      display: -webkit-box;
+      font-family: #{css(fonts["heading"])};
+      font-size: 72px;
+      font-weight: 700;
+      letter-spacing: -.055em;
+      line-height: .96;
+      overflow: hidden;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+    }
+    .inquiry-underline {
+      background: #{css(colors["text"])};
+      display: block;
+      height: 7px;
+      margin-top: 16px;
+      width: 58%;
+    }
+    .inquiry-context { display: flex; flex-direction: column; gap: 34px; }
+    .inquiry-subtitle {
+      color: #{css(colors["text"])};
+      display: -webkit-box;
+      font-family: #{css(fonts["body"])};
+      font-size: 31px;
+      line-height: 1.2;
+      overflow: hidden;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+    }
+    .inquiry-orbit { align-items: center; display: flex; gap: 15px; }
+    .inquiry-orbit span { background: #{css(colors["surface"])}; border-radius: 50%; display: block; height: 34px; width: 34px; }
+    .inquiry-orbit span:nth-child(2) { background: #{css(colors["accent"])}; height: 56px; width: 56px; }
+    .inquiry-orbit span:nth-child(3) { background: #{css(colors["highlight"])}; height: 24px; width: 24px; }
+    .inquiry-foot {
+      align-items: center;
+      display: flex;
+      font-family: #{css(fonts["heading"])};
+      font-size: 19px;
+      justify-content: space-between;
+    }
+    .inquiry-foot span:last-child { text-decoration: underline; text-underline-offset: 5px; }
+    """
+  end
+
+  defp layout_styles("default", colors, fonts) do
+    """
+    body { display: flex; flex-direction: column; justify-content: space-between; padding: 72px 80px; }
+    .accent-bar { background: #{css(colors["primary"])}; border-radius: 9999px; height: 10px; width: 96px; }
+    .eyebrow { color: #{css(colors["mutedText"])}; font-size: 26px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; }
+    .title { color: #{css(colors["text"])}; display: -webkit-box; font-family: #{css(fonts["heading"])}; font-size: 78px; font-weight: 700; line-height: 1.08; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 3; }
+    .subtitle { color: #{css(colors["mutedText"])}; display: -webkit-box; font-size: 34px; line-height: 1.4; overflow: hidden; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
+    .stack { display: flex; flex-direction: column; gap: 28px; }
+    .head { display: flex; flex-direction: column; gap: 24px; }
+    .foot { align-items: center; border-top: 2px solid #{css(colors["border"])}; color: #{css(colors["mutedText"])}; display: flex; font-size: 26px; justify-content: space-between; padding-top: 28px; }
+    .foot .meta { color: #{css(colors["accent"])}; font-weight: 600; }
+    """
+  end
+
+  defp layout_markup("studio", eyebrow, title, subtitle, meta) do
+    """
+    <header class="studio-top">
+      <span class="studio-wordmark">#{escape(eyebrow)}</span>
+      <span class="studio-meta">#{escape(meta_label(meta))}</span>
+    </header>
+    <main class="studio-main">
+      <div class="studio-copy">
+        <div class="studio-title">#{escape(title)}</div>
+        #{subtitle_markup("studio-subtitle", subtitle)}
+      </div>
+      <div class="studio-panels" aria-hidden="true"><span class="studio-panel"></span><span class="studio-panel"></span><span class="studio-panel"></span></div>
+    </main>
+    <footer class="studio-foot"><span>Independent publishing</span><span>Read ↗</span></footer>
+    """
+  end
+
+  defp layout_markup("inquiry", eyebrow, title, subtitle, meta) do
+    """
+    <header class="inquiry-top">
+      <span class="inquiry-wordmark">#{escape(eyebrow)}</span>
+      <span class="inquiry-meta">#{escape(meta_label(meta))}</span>
+    </header>
+    <main class="inquiry-main">
+      <div class="inquiry-heading"><div class="inquiry-title">#{escape(title)}</div><span class="inquiry-underline"></span></div>
+      <div class="inquiry-context">
+        #{subtitle_markup("inquiry-subtitle", subtitle)}
+        <div class="inquiry-orbit" aria-hidden="true"><span></span><span></span><span></span></div>
+      </div>
+    </main>
+    <footer class="inquiry-foot"><span>Questions, observations, and lasting notes.</span><span>Read more ↗</span></footer>
+    """
+  end
+
+  defp layout_markup("default", eyebrow, title, subtitle, meta) do
+    """
+    <div class="head">
+      <div class="accent-bar"></div>
+      <div class="eyebrow">#{escape(eyebrow)}</div>
+    </div>
+    <div class="stack">
+      <div class="title">#{escape(title)}</div>
+      #{subtitle_markup("subtitle", subtitle)}
+    </div>
+    <div class="foot">
+      <span>#{escape(eyebrow)}</span>
+      <span class="meta">#{escape(meta)}</span>
+    </div>
+    """
+  end
+
+  defp subtitle_markup(_class, ""), do: ""
+  defp subtitle_markup(class, subtitle), do: ~s(<div class="#{class}">#{escape(subtitle)}</div>)
+
+  defp meta_label(""), do: "Latest writing"
+  defp meta_label(meta), do: meta
 
   # Escapes text destined for element content.
   defp escape(value) when is_binary(value) do

--- a/lib/gesttalt/sites/theme_defaults.ex
+++ b/lib/gesttalt/sites/theme_defaults.ex
@@ -14,15 +14,71 @@ defmodule Gesttalt.Sites.ThemeDefaults do
 
   @themes [
     %{
+      id: "inquiry",
+      name: "Inquiry",
+      description: "A warm, rigorous journal pairing bold headlines with literary reading type.",
+      template_dir: "inquiry",
+      variables: %{
+        "colors" => %{
+          "accent" => "#d97857",
+          "background" => "#f7f6f1",
+          "border" => "#cbc7bc",
+          "highlight" => "#d7ddca",
+          "muted" => "#efede6",
+          "mutedText" => "#67655f",
+          "primary" => "#171714",
+          "secondary" => "#484741",
+          "surface" => "#e5ded1",
+          "text" => "#171714"
+        },
+        "fonts" => %{
+          "body" => "Georgia, 'Times New Roman', serif",
+          "heading" => "Arial, Helvetica, sans-serif"
+        },
+        "fontWeights" => %{"heading" => "700"},
+        "lineHeights" => %{"body" => "1.45", "heading" => "1"},
+        "radii" => %{"large" => "1.25rem", "medium" => "0.65rem", "small" => "0.25rem"},
+        "shadows" => %{"card" => "none"},
+        "sizes" => %{"content" => "1272px"}
+      }
+    },
+    %{
+      id: "studio",
+      name: "Studio",
+      description: "A spacious editorial canvas with bold statements and modular stories.",
+      template_dir: "studio",
+      variables: %{
+        "colors" => %{
+          "accent" => "#8d4f2f",
+          "background" => "#f7f7f2",
+          "border" => "#c9c9c1",
+          "highlight" => "#d9e8ff",
+          "muted" => "#e9e9e2",
+          "mutedText" => "#65655f",
+          "primary" => "#11110f",
+          "secondary" => "#30302c",
+          "surface" => "#edede7",
+          "text" => "#11110f"
+        },
+        "fontWeights" => %{"heading" => "600"},
+        "lineHeights" => %{"body" => "1.55", "heading" => "0.98"},
+        "radii" => %{"large" => "1.5rem", "medium" => "0.75rem", "small" => "0.3rem"},
+        "shadows" => %{"card" => "none"},
+        "sizes" => %{"content" => "1200px"}
+      }
+    },
+    %{
       id: "paper",
       name: "Paper",
       description: "A quiet, considered journal for writing and photographs.",
+      template_dir: "paper",
       variables: %{}
     },
     %{
       id: "ledger",
       name: "Ledger",
       description: "A typographic, newspaper-inspired publication with crisp rules.",
+      template_dir: "paper",
       variables: %{
         "colors" => %{
           "background" => "#f5f1e8",
@@ -44,6 +100,7 @@ defmodule Gesttalt.Sites.ThemeDefaults do
       id: "darkroom",
       name: "Darkroom",
       description: "A dark, image-first portfolio with minimal visual noise.",
+      template_dir: "paper",
       variables: %{
         "colors" => %{
           "background" => "#121211",
@@ -62,6 +119,7 @@ defmodule Gesttalt.Sites.ThemeDefaults do
       id: "field-notes",
       name: "Field Notes",
       description: "A warm, practical notebook for observations, essays, and travel.",
+      template_dir: "paper",
       variables: %{
         "colors" => %{
           "background" => "#f4eedf",
@@ -118,7 +176,7 @@ defmodule Gesttalt.Sites.ThemeDefaults do
 
   def all, do: @themes
 
-  def default_id, do: "paper"
+  def default_id, do: "inquiry"
 
   def fetch(id) when is_binary(id) do
     case Enum.find(@themes, &(&1.id == id)) do
@@ -136,7 +194,7 @@ defmodule Gesttalt.Sites.ThemeDefaults do
     end
   end
 
-  def photography_template, do: read!("photography.liquid")
+  def photography_template, do: read!(paper_theme(), "photography.liquid")
 
   def preview_style(id) when is_binary(id) do
     variables = attrs(id).variables
@@ -173,19 +231,21 @@ defmodule Gesttalt.Sites.ThemeDefaults do
         Map.put(
           attrs,
           :stylesheet,
-          read!(filename) <> "\n" <> Map.get(@theme_styles, theme.id, "")
+          read!(theme, filename) <> "\n" <> Map.get(@theme_styles, theme.id, "")
         )
 
       {key, filename}, attrs ->
-        Map.put(attrs, key, read!(filename))
+        Map.put(attrs, key, read!(theme, filename))
     end)
   end
 
   defp default_theme, do: Enum.find(@themes, &(&1.id == default_id()))
 
-  defp read!(filename) do
+  defp paper_theme, do: Enum.find(@themes, &(&1.id == "paper"))
+
+  defp read!(theme, filename) do
     :gesttalt
-    |> Application.app_dir("priv/themes/paper/#{filename}")
+    |> Application.app_dir("priv/themes/#{theme.template_dir}/#{filename}")
     |> File.read!()
   end
 end

--- a/lib/gesttalt_web/controllers/page_html/docs.html.heex
+++ b/lib/gesttalt_web/controllers/page_html/docs.html.heex
@@ -53,7 +53,7 @@
         <section id="themes" data-part="section">
           <h2 data-part="title">Themes</h2><p>
             Start in the dashboard’s <strong>Theme</strong>
-            section, where you can choose Paper, Ledger, Darkroom, or Field Notes. The publishing dashboard reflects the selected theme’s colors and typography. Built-in themes remain application-maintained, so improvements arrive automatically until you or an agent customize the theme.
+            section, where you can choose Inquiry, Studio, Paper, Ledger, Darkroom, or Field Notes. The publishing dashboard reflects the selected theme’s colors and typography. Built-in themes remain application-maintained, so improvements arrive automatically until you or an agent customize the theme.
           </p><p>
             Selecting a built-in theme replaces an existing custom theme with that theme’s templates, styles, and variables. Use it when you want a deliberate fresh starting point for the publication.
           </p><h3>Live theme editing</h3><p>

--- a/priv/changelog/2026-08-11-editorial-themes.md
+++ b/priv/changelog/2026-08-11-editorial-themes.md
@@ -1,0 +1,11 @@
+%{
+  title: "Two new editorial themes",
+  summary: "New publications begin with Inquiry, while Studio offers a spacious modern alternative."
+}
+---
+
+New publications now inherit Inquiry, a warm editorial theme with assertive headlines, literary reading type, asymmetrical layouts, and fine rules. Its writing, notes, pages, articles, and photography feed share one responsive visual language.
+
+The theme chooser also includes Studio, a spacious modern design with large type, compact navigation, and modular story cards. Both themes remain fully editable through the theme dashboard and live editing sessions. Existing publications keep their selected or customized theme, while newly seeded development publications show Inquiry automatically.
+
+Shared links now carry the same personality as the selected theme. Inquiry social previews use its split editorial composition and organic accent, while Studio previews use its bold type, modular color rail, and dark action bar. Local storage also handles the first uncached preview request correctly in development.

--- a/priv/themes/inquiry/article.liquid
+++ b/priv/themes/inquiry/article.liquid
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ post.title }} · {{ site.name }}</title>
+    <meta name="description" content="{{ post.excerpt }}">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="{{ post.title }}">
+    <meta property="og:description" content="{{ post.excerpt }}">
+    <meta property="og:image" content="{{ post.og_image }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{{ post.og_image }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="{% if post.kind == 'note' %}/notes/feed.xml{% else %}/blog/feed.xml{% endif %}">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="{% if post.kind == 'note' %}/notes/atom.xml{% else %}/blog/atom.xml{% endif %}">
+    <style>{{ stylesheet }}</style>
+  </head>
+  <body id="site-article">
+    <header id="inquiry-header"><div class="container" data-part="inner"><a data-part="wordmark" href="/">{{ site.name }}</a><nav data-part="navigation" aria-label="Publication"><a href="/blog">Writing</a><a href="/notes">Notes</a><a href="/photography">Photography</a>{% for page in pages %}<a href="{{ page.url }}">{{ page.title }}</a>{% endfor %}</nav></div></header>
+    <main class="container">
+      <article id="inquiry-article">
+        <header data-part="heading"><div data-part="metadata"><a href="{% if post.kind == 'note' %}/notes{% else %}/blog{% endif %}">{% if post.kind == 'note' %}Notes{% else %}Writing{% endif %}</a><time datetime="{{ post.published_at }}">{{ post.published_on }}</time></div>{% if post.title != "" %}<h1 data-part="title">{{ post.title }}</h1>{% endif %}{% if post.excerpt != "" %}<p data-part="lede">{{ post.excerpt }}</p>{% endif %}</header>
+        <div data-part="body" class="prose">{{ post.body_html }}</div>
+      </article>
+    </main>
+    <footer id="inquiry-footer"><div class="container" data-part="inner"><a data-part="identity" href="/">{{ site.name }}</a><div data-part="details"><a href="/">All writing</a><span data-part="powered-by">Powered by <a href="https://gesttalt.org">Gesttalt</a></span></div></div></footer>
+  </body>
+</html>

--- a/priv/themes/inquiry/index.liquid
+++ b/priv/themes/inquiry/index.liquid
@@ -36,9 +36,12 @@
         <div data-part="grid">
           {% for post in posts %}
           <article id="publication-{{ post.id }}" data-part="story" data-kind="{% if is_notes %}note{% else %}article{% endif %}">
-            <div data-part="metadata"><span>{% if is_notes %}Note{% else %}Writing{% endif %}</span><time datetime="{{ post.published_at }}">{{ post.published_on }}</time></div>
+            <div data-part="metadata">
+              <span>{% if is_notes %}Note{% else %}Writing{% endif %}</span>
+              {% if is_notes %}<a data-part="permalink" href="{{ post.url }}"><time datetime="{{ post.published_at }}">{{ post.published_on }}</time></a>{% else %}<time datetime="{{ post.published_at }}">{{ post.published_on }}</time>{% endif %}
+            </div>
             {% if is_notes %}
-            <a data-part="note" href="{{ post.url }}">{{ post.body }}</a>
+            <div data-part="note">{% if post.body_html %}{{ post.body_html }}{% else %}<p>{{ post.body }}</p>{% endif %}</div>
             {% else %}
             <h2 data-part="story-title"><a href="{{ post.url }}">{{ post.title }}</a></h2><p data-part="excerpt">{{ post.excerpt }}</p><a data-part="story-action" href="{{ post.url }}" aria-label="Read {{ post.title }}">Read more <span aria-hidden="true">↗</span></a>
             {% endif %}

--- a/priv/themes/inquiry/index.liquid
+++ b/priv/themes/inquiry/index.liquid
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if is_notes %}Notes · {% elsif is_archive %}Writing · {% endif %}{{ site.name }}</title>
+    <meta name="description" content="{{ site.tagline }}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{ site.name }}">
+    <meta property="og:description" content="{{ site.tagline }}">
+    <meta property="og:image" content="{{ og_image }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{{ og_image }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="{% if is_notes %}/notes/feed.xml{% else %}/blog/feed.xml{% endif %}">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="{% if is_notes %}/notes/atom.xml{% else %}/blog/atom.xml{% endif %}">
+    <style>{{ stylesheet }}</style>
+  </head>
+  <body id="{% if is_notes %}site-notes{% elsif is_archive %}site-blog{% else %}site-home{% endif %}">
+    <header id="inquiry-header">
+      <div class="container" data-part="inner">
+        <a data-part="wordmark" href="/">{{ site.name }}</a>
+        <nav data-part="navigation" aria-label="Publication">
+          <a href="/blog">Writing</a><a href="/notes">Notes</a><a href="/photography">Photography</a>{% for page in pages %}<a href="{{ page.url }}">{{ page.title }}</a>{% endfor %}
+        </nav>
+      </div>
+    </header>
+    <main>
+      {% unless is_archive %}
+      <section id="inquiry-introduction" class="container">
+        <h1 data-part="title">{{ site.tagline }}</h1>
+        <div data-part="context">{% if site.has_description %}<div data-part="description" class="prose">{{ site.description_html }}</div>{% else %}<p>{{ site.name }} is an independent publication for ideas worth examining.</p>{% endif %}<a data-part="archive-action" href="{{ archive_url }}">Explore the archive <span aria-hidden="true">↗</span></a></div>
+      </section>
+      {% endunless %}
+      <section id="inquiry-stories" class="container">
+        <header data-part="heading"><h1 data-part="title">{% if is_notes %}Notes{% elsif is_archive %}Writing{% else %}Latest writing{% endif %}</h1><p data-part="description">{% if is_notes %}Short observations from the work in progress.{% elsif is_archive %}Essays, field reports, and lasting notes.{% else %}Questions, observations, and work worth sharing.{% endif %}</p></header>
+        <div data-part="grid">
+          {% for post in posts %}
+          <article id="publication-{{ post.id }}" data-part="story" data-kind="{% if is_notes %}note{% else %}article{% endif %}">
+            <div data-part="metadata"><span>{% if is_notes %}Note{% else %}Writing{% endif %}</span><time datetime="{{ post.published_at }}">{{ post.published_on }}</time></div>
+            {% if is_notes %}
+            <a data-part="note" href="{{ post.url }}">{{ post.body }}</a>
+            {% else %}
+            <h2 data-part="story-title"><a href="{{ post.url }}">{{ post.title }}</a></h2><p data-part="excerpt">{{ post.excerpt }}</p><a data-part="story-action" href="{{ post.url }}" aria-label="Read {{ post.title }}">Read more <span aria-hidden="true">↗</span></a>
+            {% endif %}
+          </article>
+          {% endfor %}
+        </div>
+        {% if pagination.total_pages > 1 %}
+        <nav id="posts-pagination" aria-label="{% if is_notes %}Notes{% else %}Writing{% endif %} pages">
+          {% if pagination.previous_url %}<a data-part="previous" href="{{ pagination.previous_url }}">Newer posts</a>{% endif %}<span data-part="status">Page {{ pagination.current_page }} of {{ pagination.total_pages }}</span>{% if pagination.next_url %}<a data-part="next" href="{{ pagination.next_url }}">Older posts</a>{% endif %}
+        </nav>
+        {% endif %}
+        {% unless is_archive %}<p data-part="archive-link"><a href="{{ archive_url }}">View all writing</a></p>{% endunless %}
+      </section>
+    </main>
+    <footer id="inquiry-footer">
+      <div class="container" data-part="inner"><p data-part="identity">{{ site.name }}</p><div data-part="details"><span data-part="feeds">{% if is_notes %}<a href="/notes/feed.xml">Really Simple Syndication</a> · <a href="/notes/atom.xml">Atom</a>{% else %}<a href="/blog/feed.xml">Really Simple Syndication</a> · <a href="/blog/atom.xml">Atom</a>{% endif %}</span><span data-part="powered-by">Powered by <a href="https://gesttalt.org">Gesttalt</a></span></div></div>
+    </footer>
+  </body>
+</html>

--- a/priv/themes/inquiry/page.liquid
+++ b/priv/themes/inquiry/page.liquid
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title }} · {{ site.name }}</title>
+    <meta name="description" content="{{ page.excerpt }}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{ page.title }}">
+    <meta property="og:description" content="{{ page.excerpt }}">
+    <meta property="og:image" content="{{ page.og_image }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{{ page.og_image }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="/blog/feed.xml">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="/blog/atom.xml">
+    <style>{{ stylesheet }}</style>
+  </head>
+  <body id="site-page">
+    <header id="inquiry-header"><div class="container" data-part="inner"><a data-part="wordmark" href="/">{{ site.name }}</a><nav data-part="navigation" aria-label="Publication"><a href="/blog">Writing</a><a href="/notes">Notes</a><a href="/photography">Photography</a>{% for item in pages %}<a href="{{ item.url }}">{{ item.title }}</a>{% endfor %}</nav></div></header>
+    <main class="container"><article id="inquiry-page"><header data-part="heading"><p data-part="eyebrow">{{ site.name }}</p><h1 data-part="title">{{ page.title }}</h1>{% if page.has_excerpt %}<p data-part="lede">{{ page.excerpt }}</p>{% endif %}</header><div data-part="body" class="prose">{{ page.body_html }}</div></article></main>
+    <footer id="inquiry-footer"><div class="container" data-part="inner"><a data-part="identity" href="/">{{ site.name }}</a><div data-part="details"><a href="/">Home</a><span data-part="powered-by">Powered by <a href="https://gesttalt.org">Gesttalt</a></span></div></div></footer>
+  </body>
+</html>

--- a/priv/themes/inquiry/photography.liquid
+++ b/priv/themes/inquiry/photography.liquid
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Photography · {{ site.name }}</title>
+    <meta name="description" content="A photography feed by {{ site.name }}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Photography · {{ site.name }}">
+    <meta property="og:description" content="A photography feed by {{ site.name }}">
+    <meta property="og:image" content="{{ og_image }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{{ og_image }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="/blog/feed.xml">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="/blog/atom.xml">
+    <style>{{ stylesheet }}</style>
+  </head>
+  <body id="site-photography">
+    <header id="inquiry-header"><div class="container" data-part="inner"><a data-part="wordmark" href="/">{{ site.name }}</a><nav data-part="navigation" aria-label="Publication"><a href="/blog">Writing</a><a href="/notes">Notes</a><a href="/photography" aria-current="page">Photography</a>{% for page in pages %}<a href="{{ page.url }}">{{ page.title }}</a>{% endfor %}</nav></div></header>
+    <main class="container"><section id="inquiry-photography"><header data-part="heading"><h1 data-part="title">Photography</h1><p data-part="description">A visual record of places, details, and passing light.</p></header>{% if photos.size == 0 %}<div data-part="empty"><p>No photographs have been published yet.</p></div>{% else %}<div data-part="grid" aria-label="Photography feed">{% for photo in photos %}<article id="photo-{{ photo.id }}" data-part="entry"><img data-part="image" src="{{ photo.image_url }}" alt="{{ photo.alt_text }}" loading="lazy"><div data-part="caption"><time datetime="{{ photo.published_at }}">{{ photo.published_on }}</time>{% if photo.caption != "" %}<p>{{ photo.caption }}</p>{% endif %}</div></article>{% endfor %}</div>{% endif %}</section></main>
+    <footer id="inquiry-footer"><div class="container" data-part="inner"><a data-part="identity" href="/">{{ site.name }}</a><div data-part="details"><a href="/">Read the writing</a><span data-part="powered-by">Powered by <a href="https://gesttalt.org">Gesttalt</a></span></div></div></footer>
+  </body>
+</html>

--- a/priv/themes/inquiry/theme.css
+++ b/priv/themes/inquiry/theme.css
@@ -1,0 +1,160 @@
+*, *::before, *::after { box-sizing: border-box; }
+:root { color-scheme: light; }
+html { background: var(--gesttalt-colors-background); color: var(--gesttalt-colors-text); font-family: var(--gesttalt-fonts-body); font-size: var(--gesttalt-font-sizes-body); font-weight: var(--gesttalt-font-weights-body); line-height: var(--gesttalt-line-heights-body); }
+body { margin: 0; }
+a { color: inherit; text-underline-offset: .18em; }
+img { max-width: 100%; }
+.container { margin-inline: auto; width: min(calc(100% - 3rem), var(--gesttalt-sizes-content)); }
+.prose {
+  & > * + * { margin-top: 1.2rem; }
+  & h2, & h3 { font-family: var(--gesttalt-fonts-heading); letter-spacing: -.025em; line-height: 1.05; margin-bottom: 0; margin-top: 2.5rem; }
+  & h2 { font-size: clamp(1.8rem, 3vw, 2.75rem); }
+  & h3 { font-size: 1.4rem; }
+  & img { display: block; height: auto; width: 100%; }
+  & blockquote { border-left: 2px solid var(--gesttalt-colors-text); font-size: 1.25em; margin-left: 0; padding-left: 1.25rem; }
+  & code { background: var(--gesttalt-colors-muted); font-family: var(--gesttalt-fonts-monospace); font-size: .85em; padding: .15rem .35rem; }
+  & pre { background: var(--gesttalt-colors-text); color: var(--gesttalt-colors-background); overflow-x: auto; padding: 1.25rem; }
+  & pre code { background: transparent; color: inherit; padding: 0; }
+}
+
+#inquiry-header {
+  font-family: var(--gesttalt-fonts-heading);
+
+  & > [data-part="inner"] { align-items: center; display: flex; gap: 2rem; min-height: 4.5rem; }
+  & [data-part="wordmark"] { font-size: 1.25rem; font-weight: 700; letter-spacing: .025em; text-decoration: none; text-transform: uppercase; }
+  & [data-part="navigation"] { align-items: center; display: flex; flex-wrap: wrap; gap: 1.75rem; margin-inline-start: auto; }
+  & [data-part="navigation"] a { font-size: .88rem; text-decoration: none; }
+  & [data-part="navigation"] a:hover, & [data-part="navigation"] a[aria-current="page"] { text-decoration: underline; text-decoration-thickness: 2px; }
+}
+
+#site-home, #site-blog, #site-notes {
+  & #inquiry-introduction { align-items: start; display: grid; gap: clamp(3rem, 8vw, 8rem); grid-template-columns: 1.1fr .9fr; padding-block: clamp(6rem, 12vw, 11rem) clamp(5rem, 10vw, 9rem); }
+  & #inquiry-introduction > [data-part="title"] { font-family: var(--gesttalt-fonts-heading); font-size: clamp(3.5rem, 6.2vw, 6rem); font-weight: var(--gesttalt-font-weights-heading); letter-spacing: -.055em; line-height: .98; margin: 0; max-width: 12ch; }
+  & #inquiry-introduction > [data-part="title"]::after { background: var(--gesttalt-colors-text); content: ""; display: block; height: .08em; margin-top: .12em; width: 58%; }
+  & #inquiry-introduction > [data-part="context"] { font-size: clamp(1.35rem, 2.3vw, 2rem); line-height: 1.22; padding-top: 3.5rem; }
+  & #inquiry-introduction [data-part="description"] > * { margin-bottom: 0; }
+  & #inquiry-introduction [data-part="description"] h2 { font-family: var(--gesttalt-fonts-body); font-size: inherit; font-weight: 400; letter-spacing: 0; line-height: inherit; margin-top: 0; }
+  & #inquiry-introduction [data-part="description"] ul { font-size: .62em; line-height: 1.4; padding-left: 1.1em; }
+  & #inquiry-introduction [data-part="archive-action"] { display: inline-block; font-family: var(--gesttalt-fonts-heading); font-size: .85rem; margin-top: 2rem; }
+}
+
+#inquiry-stories {
+  border-top: 1px solid var(--gesttalt-colors-border);
+  padding-block: 1.5rem clamp(5rem, 10vw, 9rem);
+
+  & > [data-part="heading"] { align-items: start; display: grid; gap: 3rem; grid-template-columns: 1fr 1fr; margin-bottom: 3rem; }
+  & > [data-part="heading"] > [data-part="title"] { font-family: var(--gesttalt-fonts-heading); font-size: clamp(2.5rem, 4.5vw, 4.5rem); letter-spacing: -.05em; margin: 0; }
+  & > [data-part="heading"] > [data-part="description"] { font-size: 1.25rem; margin: .5rem 0 0; max-width: 28rem; }
+  & > [data-part="grid"] { display: grid; gap: 0 2rem; grid-template-columns: 2fr 1fr; }
+  & [data-part="story"] { border-top: 1px solid var(--gesttalt-colors-border); display: grid; gap: .6rem; padding-block: 1.1rem; }
+  & [data-part="story"]:first-child { background: var(--gesttalt-colors-surface); border: 0; border-radius: var(--gesttalt-radii-large); grid-row: span 2; min-height: 38rem; overflow: hidden; padding: 1.5rem; position: relative; }
+  & [data-part="story"]:first-child::before { background: radial-gradient(circle at 20% 26%, #8b6751 0 3.5%, transparent 3.8%), radial-gradient(circle at 33% 48%, #c28b67 0 6%, transparent 6.3%), radial-gradient(circle at 72% 24%, #777c69 0 5%, transparent 5.3%), radial-gradient(circle at 66% 62%, #d4a37c 0 8%, transparent 8.3%), radial-gradient(circle at 45% 78%, #98947c 0 4.5%, transparent 4.8%); content: ""; inset: 0; opacity: .82; position: absolute; }
+  & [data-part="story"]:first-child > * { position: relative; z-index: 1; }
+  & [data-part="story"]:first-child [data-part="story-title"], & [data-part="story"]:first-child [data-part="note"] { font-size: clamp(2.6rem, 5vw, 5.25rem); margin-top: auto; max-width: 10ch; }
+  & [data-part="story"]:first-child [data-part="excerpt"] { font-size: 1.2rem; max-width: 30rem; }
+  & [data-part="metadata"] { display: flex; font-family: var(--gesttalt-fonts-heading); font-size: .76rem; gap: .75rem; }
+  & [data-part="metadata"] time { color: var(--gesttalt-colors-muted-text); }
+  & [data-part="story-title"] { font-family: var(--gesttalt-fonts-heading); font-size: 1.25rem; letter-spacing: -.02em; line-height: 1.05; margin: 0; }
+  & [data-part="story-title"] a, & [data-part="note"] { text-decoration: none; }
+  & [data-part="excerpt"] { margin: 0; }
+  & [data-part="story-action"] { font-family: var(--gesttalt-fonts-heading); font-size: .78rem; margin-top: .25rem; }
+  & [data-part="note"] { font-size: 1.25rem; line-height: 1.2; }
+  & > [data-part="archive-link"] { margin: 2rem 0 0; }
+  & #posts-pagination { align-items: center; display: grid; gap: 1rem; grid-template-columns: 1fr auto 1fr; padding-block: 2rem; }
+  & #posts-pagination > [data-part="previous"] { grid-column: 1; justify-self: start; }
+  & #posts-pagination > [data-part="status"] { color: var(--gesttalt-colors-muted-text); grid-column: 2; }
+  & #posts-pagination > [data-part="next"] { grid-column: 3; justify-self: end; }
+}
+
+#site-blog, #site-notes {
+  & #inquiry-stories { border-top: 0; padding-top: clamp(5rem, 9vw, 8rem); }
+  & #inquiry-stories > [data-part="heading"] { border-bottom: 1px solid var(--gesttalt-colors-border); padding-bottom: 3rem; }
+  & #inquiry-stories > [data-part="grid"] { display: block; }
+  & #inquiry-stories [data-part="story"], & #inquiry-stories [data-part="story"]:first-child {
+    align-items: start;
+    background: transparent;
+    border-radius: 0;
+    border-top: 1px solid var(--gesttalt-colors-border);
+    display: grid;
+    gap: 1.5rem;
+    grid-row: auto;
+    grid-template-columns: minmax(7rem, .25fr) minmax(13rem, .7fr) minmax(16rem, 1fr) auto;
+    min-height: 0;
+    overflow: visible;
+    padding: 1.5rem 0;
+    position: static;
+  }
+  & #inquiry-stories [data-part="story"]:first-child::before { content: none; }
+  & #inquiry-stories [data-part="story"]:first-child > * { position: static; z-index: auto; }
+  & #inquiry-stories [data-part="metadata"] { align-items: flex-start; flex-direction: column; gap: .15rem; }
+  & #inquiry-stories [data-part="story-title"], & #inquiry-stories [data-part="story"]:first-child [data-part="story-title"] { font-size: clamp(1.45rem, 2vw, 2rem); margin: 0; max-width: none; }
+  & #inquiry-stories [data-part="story"]:first-child [data-part="excerpt"] { font-size: inherit; max-width: none; }
+  & #inquiry-stories [data-part="story-action"] { justify-self: end; white-space: nowrap; }
+  & #inquiry-stories [data-part="note"], & #inquiry-stories [data-part="story"]:first-child [data-part="note"] { font-size: 1.4rem; grid-column: 2 / -1; margin: 0; max-width: none; }
+}
+
+#site-home #inquiry-stories [data-part="story"]:not(:first-child) { min-height: 19rem; }
+
+#site-article {
+  & > main { padding-block: clamp(5rem, 10vw, 9rem); }
+  & #inquiry-article > [data-part="heading"] { display: grid; gap: 2rem 5rem; grid-template-columns: 1.1fr .9fr; }
+  & #inquiry-article [data-part="metadata"] { display: flex; font-family: var(--gesttalt-fonts-heading); font-size: .8rem; gap: 1rem; grid-column: 1 / -1; }
+  & #inquiry-article [data-part="metadata"] time { color: var(--gesttalt-colors-muted-text); }
+  & #inquiry-article [data-part="title"] { font-family: var(--gesttalt-fonts-heading); font-size: clamp(3.5rem, 7vw, 7rem); letter-spacing: -.06em; line-height: .94; margin: 2rem 0 0; }
+  & #inquiry-article [data-part="lede"] { font-size: clamp(1.35rem, 2.5vw, 2.1rem); line-height: 1.2; margin: 3rem 0 0; }
+  & #inquiry-article > [data-part="body"] { border-top: 1px solid var(--gesttalt-colors-border); font-size: 1.15rem; margin-top: clamp(4rem, 8vw, 7rem); max-width: 48rem; padding-top: clamp(3rem, 6vw, 5rem); }
+}
+
+#site-page {
+  & > main { padding-block: clamp(5rem, 10vw, 9rem); }
+  & #inquiry-page > [data-part="heading"] { align-items: start; display: grid; gap: 2rem 5rem; grid-template-columns: 1.1fr .9fr; }
+  & #inquiry-page [data-part="eyebrow"] { font-family: var(--gesttalt-fonts-heading); font-size: .8rem; grid-column: 1 / -1; margin: 0; text-transform: uppercase; }
+  & #inquiry-page [data-part="title"] { font-family: var(--gesttalt-fonts-heading); font-size: clamp(4rem, 8vw, 8rem); letter-spacing: -.06em; line-height: .92; margin: 2rem 0 0; }
+  & #inquiry-page [data-part="lede"] { font-size: clamp(1.35rem, 2.5vw, 2.1rem); line-height: 1.2; margin: 3rem 0 0; }
+  & #inquiry-page > [data-part="body"] { border-top: 1px solid var(--gesttalt-colors-border); font-size: 1.15rem; margin-top: clamp(4rem, 8vw, 7rem); max-width: 48rem; padding-top: clamp(3rem, 6vw, 5rem); }
+}
+
+#site-photography {
+  & #inquiry-photography { padding-block: clamp(5rem, 10vw, 9rem); }
+  & #inquiry-photography > [data-part="heading"] { align-items: start; display: grid; gap: 3rem; grid-template-columns: 1fr 1fr; }
+  & #inquiry-photography [data-part="title"] { font-family: var(--gesttalt-fonts-heading); font-size: clamp(3.5rem, 7vw, 7rem); letter-spacing: -.06em; line-height: .94; margin: 0; }
+  & #inquiry-photography [data-part="description"] { font-size: clamp(1.3rem, 2.2vw, 1.9rem); margin: 1rem 0 0; }
+  & #inquiry-photography > [data-part="grid"] { border-top: 1px solid var(--gesttalt-colors-border); display: grid; gap: 1px; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-top: 4rem; padding-top: 2rem; }
+  & #inquiry-photography [data-part="entry"] { margin: 0; }
+  & #inquiry-photography [data-part="image"] { aspect-ratio: 4 / 3; border-radius: var(--gesttalt-radii-large); display: block; object-fit: cover; width: 100%; }
+  & #inquiry-photography [data-part="caption"] { display: grid; gap: .5rem; padding: 1rem 0 2rem; }
+  & #inquiry-photography [data-part="caption"] time { color: var(--gesttalt-colors-muted-text); font-family: var(--gesttalt-fonts-heading); font-size: .76rem; }
+  & #inquiry-photography [data-part="caption"] p { margin: 0; }
+  & #inquiry-photography > [data-part="empty"] { border-top: 1px solid var(--gesttalt-colors-border); margin-top: 4rem; min-height: 20rem; padding-top: 2rem; }
+}
+
+#inquiry-footer {
+  border-top: 1px solid var(--gesttalt-colors-border);
+  padding-block: clamp(3rem, 7vw, 6rem);
+
+  & > [data-part="inner"] { align-items: end; display: grid; gap: 3rem; grid-template-columns: 1fr auto; }
+  & [data-part="identity"] { font-family: var(--gesttalt-fonts-heading); font-size: clamp(2rem, 5vw, 4.5rem); font-weight: 700; letter-spacing: -.05em; margin: 0; text-decoration: none; }
+  & [data-part="details"] { display: grid; font-family: var(--gesttalt-fonts-heading); font-size: .78rem; gap: .6rem; justify-items: end; }
+}
+
+@media (max-width: 800px) {
+  .container { width: min(calc(100% - 2rem), var(--gesttalt-sizes-content)); }
+  #inquiry-header {
+    & > [data-part="inner"] { align-items: flex-start; flex-direction: column; gap: .8rem; padding-block: 1rem; }
+    & [data-part="navigation"] { gap: .9rem 1.25rem; margin-inline-start: 0; }
+  }
+  #site-home, #site-blog, #site-notes {
+    & #inquiry-introduction { grid-template-columns: 1fr; }
+    & #inquiry-introduction > [data-part="context"] { padding-top: 0; }
+  }
+  #inquiry-stories {
+    & > [data-part="heading"], & > [data-part="grid"] { grid-template-columns: 1fr; }
+    & [data-part="story"]:first-child { grid-row: auto; min-height: 32rem; }
+  }
+  #site-blog #inquiry-stories [data-part="story"], #site-blog #inquiry-stories [data-part="story"]:first-child, #site-notes #inquiry-stories [data-part="story"], #site-notes #inquiry-stories [data-part="story"]:first-child { gap: .65rem; grid-template-columns: 1fr; }
+  #site-blog #inquiry-stories [data-part="story-action"], #site-notes #inquiry-stories [data-part="story-action"] { justify-self: start; }
+  #site-notes #inquiry-stories [data-part="note"], #site-notes #inquiry-stories [data-part="story"]:first-child [data-part="note"] { grid-column: 1; }
+  #site-article #inquiry-article > [data-part="heading"], #site-page #inquiry-page > [data-part="heading"], #site-photography #inquiry-photography > [data-part="heading"], #site-photography #inquiry-photography > [data-part="grid"] { grid-template-columns: 1fr; }
+  #inquiry-footer > [data-part="inner"] { align-items: start; grid-template-columns: 1fr; }
+  #inquiry-footer [data-part="details"] { justify-items: start; }
+}

--- a/priv/themes/inquiry/theme.css
+++ b/priv/themes/inquiry/theme.css
@@ -54,11 +54,15 @@ img { max-width: 100%; }
   & [data-part="story"]:first-child [data-part="excerpt"] { font-size: 1.2rem; max-width: 30rem; }
   & [data-part="metadata"] { display: flex; font-family: var(--gesttalt-fonts-heading); font-size: .76rem; gap: .75rem; }
   & [data-part="metadata"] time { color: var(--gesttalt-colors-muted-text); }
+  & [data-part="permalink"] { text-decoration: none; }
+  & [data-part="permalink"]:hover { text-decoration: underline; }
   & [data-part="story-title"] { font-family: var(--gesttalt-fonts-heading); font-size: 1.25rem; letter-spacing: -.02em; line-height: 1.05; margin: 0; }
   & [data-part="story-title"] a, & [data-part="note"] { text-decoration: none; }
   & [data-part="excerpt"] { margin: 0; }
   & [data-part="story-action"] { font-family: var(--gesttalt-fonts-heading); font-size: .78rem; margin-top: .25rem; }
   & [data-part="note"] { font-size: 1.25rem; line-height: 1.2; }
+  & [data-part="note"] > :first-child { margin-top: 0; }
+  & [data-part="note"] > :last-child { margin-bottom: 0; }
   & > [data-part="archive-link"] { margin: 2rem 0 0; }
   & #posts-pagination { align-items: center; display: grid; gap: 1rem; grid-template-columns: 1fr auto 1fr; padding-block: 2rem; }
   & #posts-pagination > [data-part="previous"] { grid-column: 1; justify-self: start; }

--- a/priv/themes/studio/article.liquid
+++ b/priv/themes/studio/article.liquid
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ post.title }} · {{ site.name }}</title>
+    <meta name="description" content="{{ post.excerpt }}">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="{{ post.title }}">
+    <meta property="og:description" content="{{ post.excerpt }}">
+    <meta property="og:image" content="{{ post.og_image }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{{ post.og_image }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="{% if post.kind == 'note' %}/notes/feed.xml{% else %}/blog/feed.xml{% endif %}">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="{% if post.kind == 'note' %}/notes/atom.xml{% else %}/blog/atom.xml{% endif %}">
+    <style>{{ stylesheet }}</style>
+  </head>
+  <body id="site-article">
+    <header id="studio-header">
+      <div class="container" data-part="inner">
+        <a data-part="wordmark" href="/">{{ site.name }}</a>
+        <nav data-part="navigation" aria-label="Publication">
+          <a href="/blog">Writing</a><a href="/notes">Notes</a><a href="/photography">Photography</a>{% for page in pages %}<a href="{{ page.url }}">{{ page.title }}</a>{% endfor %}
+        </nav>
+      </div>
+    </header>
+    <main class="container">
+      <article id="studio-article">
+        <header data-part="heading">
+          <div data-part="metadata"><a href="{% if post.kind == 'note' %}/notes{% else %}/blog{% endif %}">{% if post.kind == 'note' %}Notes{% else %}Writing{% endif %}</a><time datetime="{{ post.published_at }}">{{ post.published_on }}</time></div>
+          {% if post.title != "" %}<h1 data-part="title">{{ post.title }}</h1>{% endif %}
+          {% if post.excerpt != "" %}<p data-part="lede">{{ post.excerpt }}</p>{% endif %}
+        </header>
+        <div data-part="body" class="prose">{{ post.body_html }}</div>
+      </article>
+    </main>
+    <footer id="studio-footer">
+      <div class="container" data-part="inner"><a data-part="identity" href="/">{{ site.name }}</a><div data-part="details"><a href="/">All writing</a><span data-part="powered-by">Powered by <a href="https://gesttalt.org">Gesttalt</a></span></div></div>
+    </footer>
+  </body>
+</html>

--- a/priv/themes/studio/index.liquid
+++ b/priv/themes/studio/index.liquid
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if is_notes %}Notes · {% elsif is_archive %}Writing · {% endif %}{{ site.name }}</title>
+    <meta name="description" content="{{ site.tagline }}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{ site.name }}">
+    <meta property="og:description" content="{{ site.tagline }}">
+    <meta property="og:image" content="{{ og_image }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{{ og_image }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="{% if is_notes %}/notes/feed.xml{% else %}/blog/feed.xml{% endif %}">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="{% if is_notes %}/notes/atom.xml{% else %}/blog/atom.xml{% endif %}">
+    <style>{{ stylesheet }}</style>
+  </head>
+  <body id="{% if is_notes %}site-notes{% elsif is_archive %}site-blog{% else %}site-home{% endif %}">
+    <header id="studio-header">
+      <div class="container" data-part="inner">
+        <a data-part="wordmark" href="/">{{ site.name }}</a>
+        <nav data-part="navigation" aria-label="Publication">
+          <a href="/blog">Writing</a>
+          <a href="/notes">Notes</a>
+          <a href="/photography">Photography</a>
+          {% for page in pages %}<a href="{{ page.url }}">{{ page.title }}</a>{% endfor %}
+        </nav>
+      </div>
+    </header>
+    <main>
+      {% unless is_archive %}
+      <section id="studio-introduction" class="container">
+        <p data-part="eyebrow">{{ site.name }}</p>
+        <h1 data-part="title">{{ site.tagline }}</h1>
+        {% if site.has_description %}<div data-part="description" class="prose">{{ site.description_html }}</div>{% endif %}
+        <a data-part="archive-action" href="{{ archive_url }}">Explore all writing <span aria-hidden="true">↗</span></a>
+      </section>
+      {% endunless %}
+      <section id="studio-stories" class="container">
+        <header data-part="heading">
+          <p data-part="eyebrow">{% if is_notes %}Notes{% elsif is_archive %}Archive{% else %}Latest{% endif %}</p>
+          <h1 data-part="title">{% if is_notes %}Notes{% elsif is_archive %}Writing{% else %}Recent writing{% endif %}</h1>
+        </header>
+        <div data-part="grid">
+          {% for post in posts %}
+          <article id="publication-{{ post.id }}" data-part="story" data-kind="{% if is_notes %}note{% else %}article{% endif %}">
+            <time data-part="date" datetime="{{ post.published_at }}">{{ post.published_on }}</time>
+            {% if is_notes %}
+            <a data-part="note" href="{{ post.url }}">{{ post.body }}</a>
+            {% else %}
+            <h2 data-part="story-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+            <p data-part="excerpt">{{ post.excerpt }}</p>
+            <a data-part="story-action" href="{{ post.url }}" aria-label="Read {{ post.title }}">Read <span aria-hidden="true">↗</span></a>
+            {% endif %}
+          </article>
+          {% endfor %}
+        </div>
+        {% if pagination.total_pages > 1 %}
+        <nav id="posts-pagination" aria-label="{% if is_notes %}Notes{% else %}Writing{% endif %} pages">
+          {% if pagination.previous_url %}<a data-part="previous" href="{{ pagination.previous_url }}">Newer posts</a>{% endif %}
+          <span data-part="status">Page {{ pagination.current_page }} of {{ pagination.total_pages }}</span>
+          {% if pagination.next_url %}<a data-part="next" href="{{ pagination.next_url }}">Older posts</a>{% endif %}
+        </nav>
+        {% endif %}
+        {% unless is_archive %}<p data-part="archive-link"><a href="{{ archive_url }}">View all writing</a></p>{% endunless %}
+      </section>
+    </main>
+    <footer id="studio-footer">
+      <div class="container" data-part="inner">
+        <p data-part="identity">{{ site.name }}</p>
+        <div data-part="details">
+          <span data-part="feeds">{% if is_notes %}<a href="/notes/feed.xml">Really Simple Syndication</a> · <a href="/notes/atom.xml">Atom</a>{% else %}<a href="/blog/feed.xml">Really Simple Syndication</a> · <a href="/blog/atom.xml">Atom</a>{% endif %}</span>
+          <span data-part="powered-by">Powered by <a href="https://gesttalt.org">Gesttalt</a></span>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/priv/themes/studio/index.liquid
+++ b/priv/themes/studio/index.liquid
@@ -44,9 +44,9 @@
         <div data-part="grid">
           {% for post in posts %}
           <article id="publication-{{ post.id }}" data-part="story" data-kind="{% if is_notes %}note{% else %}article{% endif %}">
-            <time data-part="date" datetime="{{ post.published_at }}">{{ post.published_on }}</time>
+            {% if is_notes %}<a data-part="permalink" href="{{ post.url }}"><time data-part="date" datetime="{{ post.published_at }}">{{ post.published_on }}</time></a>{% else %}<time data-part="date" datetime="{{ post.published_at }}">{{ post.published_on }}</time>{% endif %}
             {% if is_notes %}
-            <a data-part="note" href="{{ post.url }}">{{ post.body }}</a>
+            <div data-part="note">{% if post.body_html %}{{ post.body_html }}{% else %}<p>{{ post.body }}</p>{% endif %}</div>
             {% else %}
             <h2 data-part="story-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
             <p data-part="excerpt">{{ post.excerpt }}</p>

--- a/priv/themes/studio/page.liquid
+++ b/priv/themes/studio/page.liquid
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title }} · {{ site.name }}</title>
+    <meta name="description" content="{{ page.excerpt }}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{ page.title }}">
+    <meta property="og:description" content="{{ page.excerpt }}">
+    <meta property="og:image" content="{{ page.og_image }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{{ page.og_image }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="/blog/feed.xml">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="/blog/atom.xml">
+    <style>{{ stylesheet }}</style>
+  </head>
+  <body id="site-page">
+    <header id="studio-header">
+      <div class="container" data-part="inner">
+        <a data-part="wordmark" href="/">{{ site.name }}</a>
+        <nav data-part="navigation" aria-label="Publication"><a href="/blog">Writing</a><a href="/notes">Notes</a><a href="/photography">Photography</a>{% for item in pages %}<a href="{{ item.url }}">{{ item.title }}</a>{% endfor %}</nav>
+      </div>
+    </header>
+    <main class="container">
+      <article id="studio-page">
+        <header data-part="heading"><p data-part="eyebrow">{{ site.name }}</p><h1 data-part="title">{{ page.title }}</h1>{% if page.has_excerpt %}<p data-part="lede">{{ page.excerpt }}</p>{% endif %}</header>
+        <div data-part="body" class="prose">{{ page.body_html }}</div>
+      </article>
+    </main>
+    <footer id="studio-footer">
+      <div class="container" data-part="inner"><a data-part="identity" href="/">{{ site.name }}</a><div data-part="details"><a href="/">Home</a><span data-part="powered-by">Powered by <a href="https://gesttalt.org">Gesttalt</a></span></div></div>
+    </footer>
+  </body>
+</html>

--- a/priv/themes/studio/photography.liquid
+++ b/priv/themes/studio/photography.liquid
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Photography · {{ site.name }}</title>
+    <meta name="description" content="A photography feed by {{ site.name }}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Photography · {{ site.name }}">
+    <meta property="og:description" content="A photography feed by {{ site.name }}">
+    <meta property="og:image" content="{{ og_image }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{{ og_image }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Really Simple Syndication feed" href="/blog/feed.xml">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} Atom feed" href="/blog/atom.xml">
+    <style>{{ stylesheet }}</style>
+  </head>
+  <body id="site-photography">
+    <header id="studio-header">
+      <div class="container" data-part="inner">
+        <a data-part="wordmark" href="/">{{ site.name }}</a>
+        <nav data-part="navigation" aria-label="Publication"><a href="/blog">Writing</a><a href="/notes">Notes</a><a href="/photography" aria-current="page">Photography</a>{% for page in pages %}<a href="{{ page.url }}">{{ page.title }}</a>{% endfor %}</nav>
+      </div>
+    </header>
+    <main class="container">
+      <section id="studio-photography">
+        <header data-part="heading"><p data-part="eyebrow">Visual notes</p><h1 data-part="title">Photography</h1></header>
+        {% if photos.size == 0 %}
+        <div data-part="empty"><p>No photographs have been published yet.</p></div>
+        {% else %}
+        <div data-part="grid" aria-label="Photography feed">
+          {% for photo in photos %}
+          <article id="photo-{{ photo.id }}" data-part="entry">
+            <img data-part="image" src="{{ photo.image_url }}" alt="{{ photo.alt_text }}" loading="lazy">
+            <div data-part="caption"><time datetime="{{ photo.published_at }}">{{ photo.published_on }}</time>{% if photo.caption != "" %}<p>{{ photo.caption }}</p>{% endif %}</div>
+          </article>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </section>
+    </main>
+    <footer id="studio-footer">
+      <div class="container" data-part="inner"><a data-part="identity" href="/">{{ site.name }}</a><div data-part="details"><a href="/">Read the writing</a><span data-part="powered-by">Powered by <a href="https://gesttalt.org">Gesttalt</a></span></div></div>
+    </footer>
+  </body>
+</html>

--- a/priv/themes/studio/theme.css
+++ b/priv/themes/studio/theme.css
@@ -59,6 +59,8 @@ img { max-width: 100%; }
   & [data-part="story"]:nth-child(3n + 2) { background: #eee2ff; }
   & [data-part="story"]:nth-child(3n + 3) { background: #f5e3d5; }
   & [data-part="date"] { color: var(--gesttalt-colors-muted-text); font-size: .8rem; }
+  & [data-part="permalink"] { align-self: start; text-decoration: none; }
+  & [data-part="permalink"]:hover { text-decoration: underline; }
   & [data-part="story-title"] { font-family: var(--gesttalt-fonts-heading); font-size: clamp(2rem, 3.5vw, 3.5rem); font-weight: 500; grid-row: 3; letter-spacing: -.055em; line-height: .98; margin: 0 0 1rem; }
   & [data-part="story-title"] a, & [data-part="note"] { text-decoration: none; }
   & [data-part="excerpt"] { grid-row: 4; margin: 0; max-width: 28rem; }
@@ -66,6 +68,8 @@ img { max-width: 100%; }
   & [data-part="story-action"]:hover { background: var(--gesttalt-colors-text); color: var(--gesttalt-colors-background); }
   & [data-part="story"][data-kind="note"] { display: flex; flex-direction: column; min-height: 20rem; }
   & [data-part="note"] { font-size: clamp(1.35rem, 2.5vw, 2.25rem); letter-spacing: -.03em; line-height: 1.12; margin-block: auto; }
+  & [data-part="note"] > :first-child { margin-top: 0; }
+  & [data-part="note"] > :last-child { margin-bottom: 0; }
   & > [data-part="archive-link"] { margin: 2rem 0 0; }
   & #posts-pagination { align-items: center; display: grid; gap: 1rem; grid-template-columns: 1fr auto 1fr; padding-block: 2rem; }
   & #posts-pagination > [data-part="previous"] { grid-column: 1; justify-self: start; }

--- a/priv/themes/studio/theme.css
+++ b/priv/themes/studio/theme.css
@@ -1,0 +1,148 @@
+*, *::before, *::after { box-sizing: border-box; }
+:root { color-scheme: light; }
+html {
+  background: var(--gesttalt-colors-background);
+  color: var(--gesttalt-colors-text);
+  font-family: var(--gesttalt-fonts-body);
+  font-size: var(--gesttalt-font-sizes-body);
+  font-weight: var(--gesttalt-font-weights-body);
+  line-height: var(--gesttalt-line-heights-body);
+}
+body { margin: 0; }
+a { color: inherit; text-underline-offset: .2em; }
+img { max-width: 100%; }
+.container { margin-inline: auto; width: min(calc(100% - 3rem), var(--gesttalt-sizes-content)); }
+.prose {
+  & > * { max-width: 46rem; }
+  & > * + * { margin-top: 1.2rem; }
+  & h2, & h3 { font-family: var(--gesttalt-fonts-heading); line-height: 1.08; margin-bottom: 0; margin-top: 2.5rem; }
+  & h2 { font-size: clamp(1.75rem, 3vw, 2.75rem); letter-spacing: -.035em; }
+  & h3 { font-size: 1.35rem; }
+  & a { text-decoration-thickness: 1px; }
+  & img { display: block; height: auto; width: 100%; }
+  & blockquote { border-left: 2px solid var(--gesttalt-colors-text); color: var(--gesttalt-colors-muted-text); margin-left: 0; padding-left: 1.25rem; }
+  & code { background: var(--gesttalt-colors-muted); font-family: var(--gesttalt-fonts-monospace); font-size: .9em; padding: .15rem .35rem; }
+  & pre { background: var(--gesttalt-colors-text); color: var(--gesttalt-colors-background); overflow-x: auto; padding: 1.25rem; }
+  & pre code { background: transparent; color: inherit; padding: 0; }
+}
+
+#studio-header {
+  border-bottom: 1px solid var(--gesttalt-colors-border);
+
+  & > [data-part="inner"] { align-items: center; display: flex; gap: 2rem; min-height: 4.25rem; }
+  & [data-part="wordmark"] { font-size: 1.1rem; font-weight: 700; letter-spacing: -.035em; text-decoration: none; }
+  & [data-part="navigation"] { align-items: center; display: flex; flex-wrap: wrap; gap: .25rem; margin-inline-start: auto; }
+  & [data-part="navigation"] a { border-radius: var(--gesttalt-radii-round); font-size: .82rem; padding: .45rem .72rem; text-decoration: none; }
+  & [data-part="navigation"] a:hover, & [data-part="navigation"] a[aria-current="page"] { background: var(--gesttalt-colors-text); color: var(--gesttalt-colors-background); }
+}
+
+#site-home, #site-blog, #site-notes {
+  & #studio-introduction { padding-block: clamp(4.5rem, 10vw, 9rem); }
+  & #studio-introduction > [data-part="eyebrow"] { font-size: .82rem; margin: 0 0 1.5rem; }
+  & #studio-introduction > [data-part="title"] { font-family: var(--gesttalt-fonts-heading); font-size: clamp(3.5rem, 8.5vw, 8.5rem); font-weight: var(--gesttalt-font-weights-heading); letter-spacing: -.07em; line-height: .9; margin: 0; max-width: 11ch; }
+  & #studio-introduction > [data-part="description"] { border-top: 1px solid var(--gesttalt-colors-border); display: grid; gap: 2rem; grid-template-columns: minmax(0, 1fr) minmax(16rem, 32rem); margin-top: clamp(3rem, 8vw, 7rem); padding-top: 1.5rem; }
+  & #studio-introduction > [data-part="description"] > * { grid-column: 2; margin-bottom: 0; margin-top: 0; }
+  & #studio-introduction > [data-part="description"] > h2 { font-size: clamp(2rem, 4vw, 3.75rem); grid-column: 1; line-height: .98; }
+  & #studio-introduction > [data-part="archive-action"] { align-items: center; background: var(--gesttalt-colors-text); border-radius: var(--gesttalt-radii-round); color: var(--gesttalt-colors-background); display: inline-flex; font-size: .88rem; gap: 1rem; margin-top: 2rem; padding: .72rem 1rem; text-decoration: none; }
+}
+
+#studio-stories {
+  border-top: 1px solid var(--gesttalt-colors-border);
+  padding-block: 1.25rem clamp(5rem, 10vw, 9rem);
+
+  & > [data-part="heading"] { align-items: baseline; display: flex; justify-content: space-between; margin-bottom: 2.5rem; }
+  & > [data-part="heading"] > [data-part="eyebrow"] { color: var(--gesttalt-colors-muted-text); font-size: .82rem; margin: 0; }
+  & > [data-part="heading"] > [data-part="title"] { font-size: clamp(1.8rem, 3vw, 3rem); font-weight: 500; letter-spacing: -.045em; margin: 0; }
+  & > [data-part="grid"] { display: grid; gap: 1px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  & [data-part="story"] { background: var(--gesttalt-colors-muted); display: grid; grid-template-rows: auto 8rem auto auto 1fr; min-height: 28rem; padding: 1.5rem; }
+  & [data-part="story"]:nth-child(3n + 1) { background: #dceaff; }
+  & [data-part="story"]:nth-child(3n + 2) { background: #eee2ff; }
+  & [data-part="story"]:nth-child(3n + 3) { background: #f5e3d5; }
+  & [data-part="date"] { color: var(--gesttalt-colors-muted-text); font-size: .8rem; }
+  & [data-part="story-title"] { font-family: var(--gesttalt-fonts-heading); font-size: clamp(2rem, 3.5vw, 3.5rem); font-weight: 500; grid-row: 3; letter-spacing: -.055em; line-height: .98; margin: 0 0 1rem; }
+  & [data-part="story-title"] a, & [data-part="note"] { text-decoration: none; }
+  & [data-part="excerpt"] { grid-row: 4; margin: 0; max-width: 28rem; }
+  & [data-part="story-action"] { align-self: end; border: 1px solid currentcolor; border-radius: var(--gesttalt-radii-round); font-size: .82rem; grid-row: 5; justify-self: start; margin-top: 1.5rem; padding: .42rem .7rem; text-decoration: none; }
+  & [data-part="story-action"]:hover { background: var(--gesttalt-colors-text); color: var(--gesttalt-colors-background); }
+  & [data-part="story"][data-kind="note"] { display: flex; flex-direction: column; min-height: 20rem; }
+  & [data-part="note"] { font-size: clamp(1.35rem, 2.5vw, 2.25rem); letter-spacing: -.03em; line-height: 1.12; margin-block: auto; }
+  & > [data-part="archive-link"] { margin: 2rem 0 0; }
+  & #posts-pagination { align-items: center; display: grid; gap: 1rem; grid-template-columns: 1fr auto 1fr; padding-block: 2rem; }
+  & #posts-pagination > [data-part="previous"] { grid-column: 1; justify-self: start; }
+  & #posts-pagination > [data-part="status"] { color: var(--gesttalt-colors-muted-text); grid-column: 2; }
+  & #posts-pagination > [data-part="next"] { grid-column: 3; justify-self: end; }
+}
+
+#site-blog, #site-notes {
+  & #studio-stories { border-top: 0; padding-top: clamp(4rem, 8vw, 7rem); }
+  & #studio-stories > [data-part="heading"] { border-bottom: 1px solid var(--gesttalt-colors-border); padding-bottom: 1.25rem; }
+}
+
+#site-article {
+  & > main { padding-block: clamp(4rem, 8vw, 8rem); }
+  & #studio-article > [data-part="heading"] { border-bottom: 1px solid var(--gesttalt-colors-border); padding-bottom: clamp(3rem, 7vw, 6rem); }
+  & #studio-article [data-part="metadata"] { display: flex; font-size: .82rem; justify-content: space-between; }
+  & #studio-article [data-part="metadata"] a { text-decoration: none; }
+  & #studio-article [data-part="metadata"] time { color: var(--gesttalt-colors-muted-text); }
+  & #studio-article [data-part="title"] { font-family: var(--gesttalt-fonts-heading); font-size: clamp(3.5rem, 9vw, 8.5rem); font-weight: var(--gesttalt-font-weights-heading); letter-spacing: -.07em; line-height: .9; margin: clamp(3rem, 7vw, 6rem) 0 0; max-width: 12ch; }
+  & #studio-article [data-part="lede"] { font-size: clamp(1.35rem, 2.5vw, 2.2rem); letter-spacing: -.025em; line-height: 1.15; margin: 2.5rem 0 0 auto; max-width: 28ch; }
+  & #studio-article > [data-part="body"] { font-size: 1.08rem; margin-inline: auto; max-width: 46rem; padding-block: clamp(3rem, 7vw, 6rem); }
+}
+
+#site-page {
+  & > main { padding-block: clamp(4rem, 8vw, 8rem); }
+  & #studio-page > [data-part="heading"] { border-bottom: 1px solid var(--gesttalt-colors-border); padding-bottom: clamp(3rem, 7vw, 6rem); }
+  & #studio-page [data-part="eyebrow"] { font-size: .82rem; margin: 0; }
+  & #studio-page [data-part="title"] { font-family: var(--gesttalt-fonts-heading); font-size: clamp(4rem, 10vw, 9rem); font-weight: var(--gesttalt-font-weights-heading); letter-spacing: -.07em; line-height: .88; margin: clamp(3rem, 7vw, 6rem) 0 0; }
+  & #studio-page [data-part="lede"] { font-size: clamp(1.35rem, 2.5vw, 2.2rem); letter-spacing: -.025em; line-height: 1.15; max-width: 32ch; }
+  & #studio-page > [data-part="body"] { font-size: 1.08rem; margin-inline: auto; max-width: 46rem; padding-block: clamp(3rem, 7vw, 6rem); }
+}
+
+#site-photography {
+  & #studio-photography { padding-block: clamp(4rem, 8vw, 8rem); }
+  & #studio-photography > [data-part="heading"] { border-bottom: 1px solid var(--gesttalt-colors-border); padding-bottom: clamp(3rem, 7vw, 6rem); }
+  & #studio-photography [data-part="eyebrow"] { font-size: .82rem; margin: 0; }
+  & #studio-photography [data-part="title"] { font-size: clamp(4rem, 10vw, 9rem); font-weight: 600; letter-spacing: -.07em; line-height: .88; margin: clamp(3rem, 7vw, 6rem) 0 0; }
+  & #studio-photography > [data-part="grid"] { display: grid; gap: 1px; grid-template-columns: repeat(2, minmax(0, 1fr)); padding-top: 1px; }
+  & #studio-photography [data-part="entry"] { background: var(--gesttalt-colors-muted); display: grid; margin: 0; }
+  & #studio-photography [data-part="image"] { aspect-ratio: 4 / 3; display: block; object-fit: cover; width: 100%; }
+  & #studio-photography [data-part="caption"] { display: grid; gap: .5rem; padding: 1rem; }
+  & #studio-photography [data-part="caption"] time { color: var(--gesttalt-colors-muted-text); font-size: .8rem; }
+  & #studio-photography [data-part="caption"] p { margin: 0; }
+  & #studio-photography > [data-part="empty"] { min-height: 22rem; padding-top: 2rem; }
+  & #studio-photography > [data-part="empty"] p { color: var(--gesttalt-colors-muted-text); }
+}
+
+#studio-footer {
+  background: var(--gesttalt-colors-text);
+  color: var(--gesttalt-colors-background);
+  padding-block: clamp(3rem, 7vw, 6rem);
+
+  & > [data-part="inner"] { align-items: flex-end; display: grid; gap: 3rem; grid-template-columns: 1fr auto; }
+  & [data-part="identity"] { font-size: clamp(2.5rem, 7vw, 6rem); font-weight: 600; letter-spacing: -.065em; line-height: .9; margin: 0; text-decoration: none; }
+  & [data-part="details"] { display: grid; font-size: .82rem; gap: .65rem; justify-items: end; }
+}
+
+@media (max-width: 800px) {
+  .container { width: min(calc(100% - 2rem), var(--gesttalt-sizes-content)); }
+  #studio-header {
+    & > [data-part="inner"] { align-items: flex-start; flex-direction: column; gap: .75rem; padding-block: 1rem; }
+    & [data-part="navigation"] { margin-inline-start: -.72rem; }
+  }
+  #site-home, #site-blog, #site-notes {
+    & #studio-introduction > [data-part="description"] { grid-template-columns: 1fr; }
+    & #studio-introduction > [data-part="description"] > * { grid-column: 1; }
+  }
+  #studio-stories {
+    & > [data-part="grid"] { grid-template-columns: 1fr; }
+    & [data-part="story"] { min-height: 23rem; }
+    & [data-part="story"] { grid-template-rows: auto 5rem auto auto 1fr; }
+  }
+  #site-photography #studio-photography > [data-part="grid"] { grid-template-columns: 1fr; }
+  #studio-footer > [data-part="inner"] { align-items: start; grid-template-columns: 1fr; }
+  #studio-footer [data-part="details"] { justify-items: start; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  #studio-header [data-part="navigation"] a, #studio-stories [data-part="story-action"] { transition: background-color 160ms ease, color 160ms ease; }
+}

--- a/test/gesttalt/open_graph/card_test.exs
+++ b/test/gesttalt/open_graph/card_test.exs
@@ -76,4 +76,36 @@ defmodule Gesttalt.OpenGraph.CardTest do
 
     assert html =~ "<!-- Theme: darkroom-v1 -->"
   end
+
+  test "uses the Studio composition for Studio cards" do
+    html =
+      Card.html(%{
+        variables: %{},
+        variant: "studio",
+        eyebrow: "Field Notes",
+        title: "A modular story",
+        subtitle: "Built from a bold grid.",
+        meta: "August 11, 2026"
+      })
+
+    assert html =~ ~s(data-layout="studio")
+    assert html =~ ~s(class="studio-panels")
+    assert html =~ "#dceaff"
+  end
+
+  test "uses the Inquiry composition for Inquiry cards" do
+    html =
+      Card.html(%{
+        variables: %{},
+        variant: "inquiry",
+        eyebrow: "Field Notes",
+        title: "A question worth examining",
+        subtitle: "A literary introduction.",
+        meta: ""
+      })
+
+    assert html =~ ~s(data-layout="inquiry")
+    assert html =~ ~s(class="inquiry-orbit")
+    assert html =~ "Latest writing"
+  end
 end

--- a/test/gesttalt/photography_test.exs
+++ b/test/gesttalt/photography_test.exs
@@ -48,7 +48,7 @@ defmodule Gesttalt.PhotographyTest do
     storage_key = photo.image.storage_key
     assert {:ok, _photo} = Photography.delete_photo(site, photo.id)
     refute Photography.get_photo(site, photo.id)
-    assert {:error, :enoent} = Gesttalt.MediaStorage.get(storage_key)
+    assert {:error, :not_found} = Gesttalt.MediaStorage.get(storage_key)
   end
 
   test "requires alternative text and keeps photos inside their publication", %{site: site} do

--- a/test/gesttalt/sites_test.exs
+++ b/test/gesttalt/sites_test.exs
@@ -187,7 +187,7 @@ defmodule Gesttalt.SitesTest do
     assert image.storage_key =~ "accounts/#{user.id}/sites/#{site.id}/"
     assert {:ok, "account image"} = Sites.fetch_image(image)
     assert {:ok, _image} = Sites.delete_image(site, image.id)
-    assert {:error, :enoent} = Gesttalt.MediaStorage.get(image.storage_key)
+    assert {:error, :not_found} = Gesttalt.MediaStorage.get(image.storage_key)
   end
 
   defp upload_fixture(filename, contents) do

--- a/test/gesttalt/sites_test.exs
+++ b/test/gesttalt/sites_test.exs
@@ -13,7 +13,7 @@ defmodule Gesttalt.SitesTest do
   end
 
   test "creates a publication with the built-in theme and no stored override", %{site: site} do
-    assert site.theme.name == "Paper"
+    assert site.theme.name == "Inquiry"
     refute Repo.get_by(Theme, site_id: site.id)
     assert [%{kind: :subdomain, status: :active} = domain] = site.domains
     assert domain.hostname == "#{site.handle}.gesttalt.test"
@@ -47,7 +47,7 @@ defmodule Gesttalt.SitesTest do
     refute Repo.get_by(Theme, site_id: site.id)
   end
 
-  test "keeps the Paper type scale across built-in themes" do
+  test "keeps the shared type scale across built-in themes" do
     paper_font_sizes = ThemeDefaults.attrs("paper").variables["fontSizes"]
 
     for %{id: id} <- ThemeDefaults.all() do

--- a/test/gesttalt/theme_editing_test.exs
+++ b/test/gesttalt/theme_editing_test.exs
@@ -31,7 +31,10 @@ defmodule Gesttalt.ThemeEditingTest do
     assert updated_session.revision == 1
     assert updated_session.theme.name == "Conversation"
     assert updated_session.theme.variables["colors"]["primary"] == "#d73a49"
-    assert updated_session.theme.variables["colors"]["background"] == "#fdfbf7"
+
+    assert updated_session.theme.variables["colors"]["background"] ==
+             original_theme.variables["colors"]["background"]
+
     assert_receive {:theme_editing_session_updated, 1}
 
     active_theme = Sites.get_theme!(site)

--- a/test/gesttalt/themes/renderer_test.exs
+++ b/test/gesttalt/themes/renderer_test.exs
@@ -4,6 +4,7 @@ defmodule Gesttalt.Themes.RendererTest do
   alias Gesttalt.AccountsFixtures
   alias Gesttalt.Publishing
   alias Gesttalt.Sites
+  alias Gesttalt.Sites.ThemeDefaults
   alias Gesttalt.Themes.Renderer
 
   setup do
@@ -125,14 +126,48 @@ defmodule Gesttalt.Themes.RendererTest do
     end
   end
 
-  test "the built-in theme left-aligns its header navigation", %{site: site} do
+  test "the default built-in theme has stable editorial structure", %{site: site} do
     theme = Sites.get_theme!(site)
 
-    assert theme.stylesheet =~
-             ".header-inner { align-items: flex-start; display: flex; flex-direction: column; gap: 1.5rem; }"
+    assert theme.stylesheet =~ "#inquiry-header"
+    assert theme.index_template =~ ~s(id="inquiry-introduction")
+    assert theme.index_template =~ ~s(id="inquiry-stories")
 
     assert {:ok, html} = Renderer.render_index(site, theme, [], [])
     assert html =~ ~s(<a href="/blog">Writing</a>)
     assert html =~ ~s(<a href="/photography">Photography</a>)
+  end
+
+  test "renders every route for the new editorial themes", %{site: site} do
+    {:ok, post} =
+      Publishing.create_post(site, %{
+        title: "A lasting question",
+        excerpt: "An introduction to the work.",
+        body: "## Begin here\n\nFollow the evidence.",
+        kind: :post,
+        status: :published
+      })
+
+    {:ok, page} =
+      Publishing.create_post(site, %{
+        title: "About",
+        body: "About this publication.",
+        kind: :page,
+        status: :published
+      })
+
+    for theme_id <- ["inquiry", "studio"] do
+      theme = ThemeDefaults.theme(site.id, theme_id)
+
+      assert {:ok, index} = Renderer.render_index(site, theme, [post], [page])
+      assert {:ok, article} = Renderer.render_article(site, theme, post, [page])
+      assert {:ok, standalone_page} = Renderer.render_page(site, theme, page, [page])
+      assert {:ok, photography} = Renderer.render_photography(site, theme, [], [page])
+
+      for html <- [index, article, standalone_page, photography] do
+        assert html =~ "Powered by"
+        assert html =~ "Gesttalt"
+      end
+    end
   end
 end

--- a/test/gesttalt_web/controllers/page_controller_test.exs
+++ b/test/gesttalt_web/controllers/page_controller_test.exs
@@ -9,7 +9,7 @@ defmodule GesttaltWeb.PageControllerTest do
     assert html =~ "Manage the whole publication"
     assert html =~ ~s(id="built-in-themes-title")
 
-    for theme <- ["Paper", "Ledger", "Darkroom", "Field Notes"] do
+    for theme <- ["Inquiry", "Studio", "Paper", "Ledger", "Darkroom", "Field Notes"] do
       assert html =~ theme
     end
 

--- a/test/gesttalt_web/controllers/publishing_interfaces_test.exs
+++ b/test/gesttalt_web/controllers/publishing_interfaces_test.exs
@@ -435,7 +435,7 @@ defmodule GesttaltWeb.PublishingInterfacesTest do
     assert call_tool(conn, token, 85, "delete_photo", %{id: photo["id"]})["deleted"]
 
     theme = call_tool(conn, token, 9, "get_theme")
-    assert theme["name"] == "Paper"
+    assert theme["name"] == "Inquiry"
     assert theme["variables"]["colors"]["primary"]
 
     domain =
@@ -487,7 +487,9 @@ defmodule GesttaltWeb.PublishingInterfacesTest do
     site: site,
     token: token
   } do
-    original_stylesheet = Sites.get_theme!(site).stylesheet
+    original_theme = Sites.get_theme!(site)
+    original_stylesheet = original_theme.stylesheet
+    original_background = original_theme.variables["colors"]["background"]
 
     created = call_tool(conn, token, 1, "create_theme_editing_session")
     session_id = created["session_id"]
@@ -508,7 +510,7 @@ defmodule GesttaltWeb.PublishingInterfacesTest do
     assert updated["revision"] == 1
     assert updated["theme"]["stylesheet"] == "body { background: papayawhip; }"
     assert updated["theme"]["variables"]["colors"]["primary"] == "#d73a49"
-    assert updated["theme"]["variables"]["colors"]["background"] == "#fdfbf7"
+    assert updated["theme"]["variables"]["colors"]["background"] == original_background
     assert Sites.get_theme!(site).stylesheet == original_stylesheet
 
     preview_path = URI.parse(updated["preview_url"]).path

--- a/test/gesttalt_web/controllers/theme_controller_test.exs
+++ b/test/gesttalt_web/controllers/theme_controller_test.exs
@@ -10,7 +10,7 @@ defmodule GesttaltWeb.ThemeControllerTest do
 
     response = conn |> get(~p"/admin/theme") |> html_response(200)
 
-    for name <- ["Paper", "Ledger", "Darkroom", "Field Notes"] do
+    for name <- ["Inquiry", "Studio", "Paper", "Ledger", "Darkroom", "Field Notes"] do
       assert response =~ name
     end
 


### PR DESCRIPTION
## What changed

Gesttalt now includes two new built-in publication themes with dedicated Liquid templates and route-scoped styles across the home page, writing archive, notes, articles, standalone pages, and photography.

Inquiry is a warm editorial theme with asymmetric headline and reading typography, restrained rules, and an intentional featured-story layout. Studio is a spacious modern theme with oversized statements, modular pastel cards, compact navigation, and aligned content axes.

Inquiry is the default for newly created publications. Studio remains available in the theme chooser. Each theme also has a dedicated [Open Graph](https://ogp.me/) social-preview composition.

Local media storage now normalizes a missing file to the shared `not found` result, allowing the first uncached social preview to render correctly in development.

## Why

Built-in themes should offer meaningfully different editorial personalities rather than small palette variations. Publishers also need social previews to carry the same visual identity as the selected publication theme.

## Root cause

Built-in themes previously loaded every template from the Paper directory, which limited theme differentiation to variables and appended styles. The Inquiry archive initially inherited its featured home grid, while Studio card content used bottom alignment that shifted short titles below wrapped titles.

The social-preview renderer used one shared composition for every theme. Local storage also returned the operating system's missing-file result directly, while the lazy rendering path expected the storage boundary's normalized `not found` result.

After this branch was opened, `main` began providing rendered Markdown through `post.body_html`. Inquiry and Studio still read the raw `post.body` value, which caused the notes-archive test to fail and would have shown Markdown syntax instead of formatted note content.

## Approach

Each built-in theme now declares its own template directory. Inquiry and Studio provide complete template sets with stable route and component identifiers, responsive layouts, and styles scoped through component parts.

Inquiry uses an editorial split on the home page and a ruled row index for full archives. Studio uses a consistent card grid where titles share one starting axis and actions remain anchored to the bottom. The social-preview renderer selects a dedicated composition from the active built-in theme while preserving the existing generic card for other themes.

Both editorial themes now render the provided note markup as content and keep the note permalink on its publication date. This avoids nesting links when a note contains its own Markdown links.

## Impact

New publications inherit Inquiry automatically. Existing publications retain their selected or customized theme. No database migration or manual action is required.

Shared links for Inquiry and Studio now render distinct 1200 by 630 social images. Fresh development environments can generate their first uncached image through local storage.

Notes containing Markdown links and emphasis now render correctly in both new themes.

## Validation

- `mix format --check-formatted`
- `mix credo --strict`, with no issues
- `ERL_FLAGS='+S 4' mix test`, with 306 tests passing
- `ERL_FLAGS='+S 4' mix test test/gesttalt_web/controllers/site_controller_test.exs:286`, with the previously failing notes test passing
- Direct Liquid rendering verified Markdown links, emphasis, and note permalinks in Inquiry and Studio
- `git diff --check`
- Headless Chrome verified home, writing, notes, article, standalone page, and photography routes at desktop and narrow widths
- Every verified public route returned status 200

## Screenshots

### Inquiry archive layout

| Before | After |
| --- | --- |
| ![Inquiry archive before the ruled index layout](https://raw.githubusercontent.com/pepicrft/gesttalt/pr-assets-editorial-themes-1f03280/inquiry-before.png) | ![Inquiry archive after the ruled index layout](https://raw.githubusercontent.com/pepicrft/gesttalt/pr-assets-editorial-themes-1f03280/inquiry-after.png) |

### Studio card positioning

| Before | After |
| --- | --- |
| ![Studio cards before title alignment](https://raw.githubusercontent.com/pepicrft/gesttalt/pr-assets-editorial-themes-1f03280/studio-before.png) | ![Studio cards after title alignment](https://raw.githubusercontent.com/pepicrft/gesttalt/pr-assets-editorial-themes-1f03280/studio-after.png) |

### Social previews

| Inquiry | Studio |
| --- | --- |
| ![Inquiry Open Graph preview](https://raw.githubusercontent.com/pepicrft/gesttalt/d0e2e59/inquiry-open-graph.jpg) | ![Studio Open Graph preview](https://raw.githubusercontent.com/pepicrft/gesttalt/d0e2e59/studio-open-graph.jpg) |

### Studio notes after Markdown integration

![Studio notes archive verified in headless Chrome](https://raw.githubusercontent.com/pepicrft/gesttalt/cfbe959/studio-notes-markdown-after.png)
